### PR TITLE
Revert "ci: Allow travis to fail on macOS until we have flatc there"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
     - GITHUB_RELEASE_VERSION=0.7.2
 
 matrix:
-  # temporary until we get flatc in the macOS build
-  allow_failures:
-    - os: osx
-
   include:
 
     - os: linux


### PR DESCRIPTION
This reverts commit 14bb603af3bfc6ff9488124ceaa8d7accbbe1025.

Now that we have flact in the prebuilt repo, we can compile on macOS once
again.