### PR TITLE
A std shim in typescript

### DIFF
--- a/run.go
+++ b/run.go
@@ -59,6 +59,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	resolver := resolve.NewResolver(worker, path.Dir(filename),
 		&resolve.StaticImporter{Specifier: "std", Source: std.Module()},
+		&resolve.StaticImporter{Specifier: "@jkcfg/std", Source: std.Module()},
 		&resolve.FileImporter{},
 	)
 	if err := worker.LoadModule(path.Base(filename), string(input), resolver.ResolveModule); err != nil {

--- a/std/package.json
+++ b/std/package.json
@@ -17,7 +17,7 @@
     "code",
     "generation"
   ],
-  "author": "Damien Lespiau",
+  "author": "The jk Authors",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/jkcfg/jk/issues"

--- a/std/shim/.gitignore
+++ b/std/shim/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/std.d.ts
+/std.js

--- a/std/shim/.npmignore
+++ b/std/shim/.npmignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/std/shim/.npmignore
+++ b/std/shim/.npmignore
@@ -1,1 +1,2 @@
 /node_modules
+*.tgz

--- a/std/shim/package-lock.json
+++ b/std/shim/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@jkcfg/std",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "dev": true
+    }
+  }
+}

--- a/std/shim/package.json
+++ b/std/shim/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@jkcfg/std",
+  "version": "0.1.0",
+  "description": "jk standard library",
+  "main": "std.js",
+  "types": "std.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jkcfg/jk.git"
+  },
+  "keywords": [
+    "configuration",
+    "code",
+    "generation"
+  ],
+  "author": "The jk Authors",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/jkcfg/jk/issues"
+  },
+  "homepage": "https://github.com/jkcfg/jk#readme",
+  "devDependencies": {
+    "typescript": "^3.2.2"
+  },
+  "dependencies": {}
+}

--- a/std/shim/std.ts
+++ b/std/shim/std.ts
@@ -12,7 +12,7 @@ interface WriteOptions {
   override?: boolean,
 }
 
-function write(value: any, path: string, options: WriteOptions): void { };
+function write(value: any, path: string, options?: WriteOptions): void { };
 
 enum Encoding {
   Bytes,
@@ -25,7 +25,7 @@ interface ReadOptions {
   encoding: Encoding,
 }
 
-function read(path: string, options: ReadOptions): Promise<ArrayBuffer | string | object> { return Promise.resolve({}) };
+function read(path: string, options?: ReadOptions): Promise<any> { return Promise.resolve({}) };
 
 export default {
   log, Format, write, read,

--- a/std/shim/std.ts
+++ b/std/shim/std.ts
@@ -1,0 +1,32 @@
+function log(value: any): void { };
+
+enum Format {
+    JSON = 1,
+    YAML,
+    Raw,
+}
+
+interface WriteOptions {
+  format?: Format,
+  indent?: number,
+  override?: boolean,
+}
+
+function write(value: any, path: string, options: WriteOptions): void { };
+
+enum Encoding {
+  Bytes,
+  String,
+  JSON,
+}
+
+interface ReadOptions {
+  format: Format,
+  encoding: Encoding,
+}
+
+function read(path: string, options: ReadOptions): Promise<ArrayBuffer | string | object> { return Promise.resolve({}) };
+
+export default {
+  log, Format, write, read,
+};

--- a/std/shim/tsconfig.json
+++ b/std/shim/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "moduleResolution": "node",
+    "sourceMap": false,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "declaration": true
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,15 +24,18 @@ $ jk run -o test-$testname.expected test-$testname.js
 - If the file `test-$testname.js.error` exists, we'll check that `jk` exits
   with an error. Otherwise, we expect `jk` to exit with 0.
 
-- If the file `test-$testname.js.cmd` exists, it's content is used as the
-  command line to execute jk. This allows to:
+- If the file `test-$testname.js.cmd` exists, its content is used as the
+  commands to excute for that tests. This allows to:
 
-    1. Use custom jk commands or options.
-    2. Run js files that aren't in the `tests/` directory.
+    1. Run several commands. Only the output of the jk command is compared to
+       the `.expected` file.
+    2. Use custom jk commands or options.
+    3. Run js files that aren't in the `tests/` directory.
 
   `.cmd` files look like:
 
   ```text
+  npm install
   jk run %t/test.js
   ```
 

--- a/tests/success.json
+++ b/tests/success.json
@@ -1,0 +1,3 @@
+{
+  "message": "success"
+}

--- a/tests/test-std-ts.js.cmd
+++ b/tests/test-std-ts.js.cmd
@@ -1,0 +1,3 @@
+npm install --prefix %t
+npm run build --prefix %t
+jk run %t/test.js

--- a/tests/test-std-ts.js.expected
+++ b/tests/test-std-ts.js.expected
@@ -1,0 +1,4 @@
+"success"
+"success"
+"success"
+"success"

--- a/tests/test-std-ts/.gitignore
+++ b/tests/test-std-ts/.gitignore
@@ -1,0 +1,3 @@
+/test.js
+/node_modules
+/package-lock.json

--- a/tests/test-std-ts/package.json
+++ b/tests/test-std-ts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "test",
+  "version": "0.1.0",
+  "description": "test case",
+  "scripts": {
+    "build": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jkcfg/jk.git"
+  },
+  "keywords": [
+    "configuration",
+    "code",
+    "generation"
+  ],
+  "author": "The jk Authors",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/jkcfg/jk/issues"
+  },
+  "homepage": "https://github.com/jkcfg/jk#readme",
+  "devDependencies": {
+    "typescript": "^3.2.2"
+  },
+  "dependencies": {}
+}

--- a/tests/test-std-ts/test.ts
+++ b/tests/test-std-ts/test.ts
@@ -1,0 +1,6 @@
+import std from 'std';
+
+std.log('success');
+std.write('success', '');
+std.write('success', '', { format: std.Format.JSON, indent: 2, override: false });
+std.read('success.json').then(json => std.log(json.message));

--- a/tests/test-std-ts/tsconfig.json
+++ b/tests/test-std-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "moduleResolution": "node",
+    "sourceMap": false,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "baseUrl": "../../std/shim"
+  }
+}


### PR DESCRIPTION
Wrote a small std shim in typescript so we can have types for the standard library. The goal is to distribute it with npm so people can put it in their devDependencies and be able to write typescript code calling std functions.

A test is included, trying to cover most of the std interface.

The shim isn't currently doing anything, it's just there for types. In the future I guess we could have something that could run on node, maybe useful for testing.