### PR TITLE
std: Add a print function

### DIFF
--- a/std/shim/std.ts
+++ b/std/shim/std.ts
@@ -1,3 +1,4 @@
+function print(...args: any[]): void { };
 function log(value: any): void { };
 
 enum Format {
@@ -28,5 +29,5 @@ interface ReadOptions {
 function read(path: string, options?: ReadOptions): Promise<any> { return Promise.resolve({}) };
 
 export default {
-  log, Format, write, read,
+  print, log, Format, write, read,
 };

--- a/std/std.js
+++ b/std/std.js
@@ -1,9 +1,11 @@
+import { print } from 'std_print';
 import { log } from 'std_log';
 import { Format, write } from 'std_write';
 import { Encoding, read } from 'std_read';
 import { info, dir } from 'std_fs';
 
 export default {
+  print,
   log,
   Format,
   write,

--- a/std/std_print.js
+++ b/std/std_print.js
@@ -1,0 +1,7 @@
+function print(...args) {
+  V8Worker2.print(args);
+}
+
+export {
+  print,
+};

--- a/tests/test-std-ts.js.expected
+++ b/tests/test-std-ts.js.expected
@@ -1,3 +1,4 @@
+success
 "success"
 "success"
 "success"

--- a/tests/test-std-ts/test.ts
+++ b/tests/test-std-ts/test.ts
@@ -1,5 +1,6 @@
 import std from 'std';
 
+std.print('success');
 std.log('success');
 std.write('success', '');
 std.write('success', '', { format: std.Format.JSON, indent: 2, override: false });


### PR DESCRIPTION
Log is designed to print out a JSON object and so isn't so convenient to print
raw strings. std.print() helps there.