### PR TITLE
Input parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/text v0.3.0
 	gopkg.in/yaml.v2 v2.2.1 // indirect

--- a/pkg/std/param.go
+++ b/pkg/std/param.go
@@ -1,0 +1,41 @@
+package std
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/jkcfg/jk/pkg/__std"
+)
+
+func param(params Params, kind __std.ParamType, path string) []byte {
+	var v interface{}
+	var err error
+
+	switch kind {
+	case __std.ParamTypeBoolean:
+		v, err = params.GetBool(path)
+	case __std.ParamTypeNumber:
+		v, err = params.GetNumber(path)
+	case __std.ParamTypeString:
+		v, err = params.GetString(path)
+	case __std.ParamTypeObject:
+		v, err = params.GetObject(path)
+	default:
+		panic("param: unexpected kind")
+	}
+
+	if err != nil && strings.Contains(err.Error(), "cannot convert") {
+		// TODO(dlespiau): return an error to throw a JS exception.
+		fmt.Fprintf(os.Stderr, "invalid type for param '%s': %v\n", path, err)
+		return []byte("null")
+	} else if err != nil {
+		// path not found.
+		return []byte("null")
+	}
+
+	// Param returns values that can be marshalled to JSON
+	data, _ := json.Marshal(v)
+	return data
+}

--- a/pkg/std/param.go
+++ b/pkg/std/param.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jkcfg/jk/pkg/__std"
 )
 
-func param(params Params, kind __std.ParamType, path string) []byte {
+func param(params Params, kind __std.ParamType, path string, defaultValue string) []byte {
 	var v interface{}
 	var err error
 
@@ -21,7 +21,17 @@ func param(params Params, kind __std.ParamType, path string) []byte {
 	case __std.ParamTypeString:
 		v, err = params.GetString(path)
 	case __std.ParamTypeObject:
+		// For object parameters, we merge the default value with what the user has
+		// given us, which could be only a part of the default value.
 		v, err = params.GetObject(path)
+		if err != nil {
+			break
+		}
+		r := strings.NewReader(defaultValue)
+		// The JS side sends us JSON.
+		base, _ := NewParamsFromJSON(r)
+		base.Merge(v.(Params))
+		v = base
 	default:
 		panic("param: unexpected kind")
 	}

--- a/pkg/std/params.go
+++ b/pkg/std/params.go
@@ -7,20 +7,6 @@ import (
 	"strings"
 )
 
-// ParamKind is the type of a parameter
-type ParamKind int
-
-const (
-	// ParamKindBoolean is the type of a boolean parameter.
-	ParamKindBoolean ParamKind = iota
-	// ParamKindNumber is the type of a number parameter.
-	ParamKindNumber
-	// ParamKindString is the type of a string parameter.
-	ParamKindString
-	// ParamKindObject is the type of an object parameter.
-	ParamKindObject
-)
-
 // Params is a paramater store akin to a JSON object.
 type Params map[string]interface{}
 

--- a/pkg/std/params.go
+++ b/pkg/std/params.go
@@ -1,0 +1,198 @@
+package std
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParamKind is the type of a parameter
+type ParamKind int
+
+const (
+	// ParamKindBoolean is the type of a boolean parameter.
+	ParamKindBoolean ParamKind = iota
+	// ParamKindNumber is the type of a number parameter.
+	ParamKindNumber
+	// ParamKindString is the type of a string parameter.
+	ParamKindString
+	// ParamKindObject is the type of an object parameter.
+	ParamKindObject
+)
+
+// Params is a paramater store akin to a JSON object.
+type Params map[string]interface{}
+
+// NewParams creates an empty set of parameters.
+func NewParams() Params {
+	return make(map[string]interface{})
+}
+
+// NewParamsFromJSON creates Params from JSON.
+func NewParamsFromJSON(r io.Reader) (Params, error) {
+	p := NewParams()
+	decoder := json.NewDecoder(r)
+	err := decoder.Decode(&p)
+	return p, err
+}
+
+// Get retrieves a parameter.
+func (p Params) Get(path string) (interface{}, error) {
+	parts := strings.Split(path, ".")
+	m := p
+	for i, part := range parts {
+		v, found := m[part]
+		if !found {
+			return nil, fmt.Errorf("invalid path (key not found): %s", strings.Join(parts[:i+1], "."))
+		}
+		// Found the value!
+		if i == len(parts)-1 {
+			// When the value is a sub-object (as opposed to a primitive value), we box
+			// it into a Params to keep the nice property that a sub-tree of Params is
+			// still a Params.
+			if retMap, ok := v.(map[string]interface{}); ok {
+				return Params(retMap), nil
+			}
+			return v, nil
+		}
+		// We can only continue if we're traversing a map.
+		if newMap, ok := v.(map[string]interface{}); ok {
+			m = Params(newMap)
+			continue
+		}
+		return nil, fmt.Errorf("invalid path (key isn't a map): %s", strings.Join(parts[:i+1], "."))
+	}
+
+	// We shouldn't reach this.
+	return nil, fmt.Errorf("invalid path (eek!): %s", path)
+}
+
+// GetBool retrieves a boolean parameter.
+func (p Params) GetBool(path string) (bool, error) {
+	v, err := p.Get(path)
+	if err != nil {
+		return false, err
+	}
+	if b, ok := v.(bool); ok {
+		return b, nil
+	}
+	return false, fmt.Errorf("cannot convert %v to bool", v)
+}
+
+// GetNumber retrieves a number parameter.
+func (p Params) GetNumber(path string) (float64, error) {
+	v, err := p.Get(path)
+	if err != nil {
+		return 0, err
+	}
+	if f, ok := v.(float64); ok {
+		return f, nil
+	}
+	return 0, fmt.Errorf("cannot convert %v to float64", v)
+}
+
+// GetString retrieves a string parameter.
+func (p Params) GetString(path string) (string, error) {
+	v, err := p.Get(path)
+	if err != nil {
+		return "", err
+	}
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	return "", fmt.Errorf("cannot convert %v to string", v)
+}
+
+// GetObject retrieves a object parameter.
+func (p Params) GetObject(path string) (Params, error) {
+	v, err := p.Get(path)
+	if err != nil {
+		return NewParams(), err
+	}
+	if o, ok := v.(Params); ok {
+		return o, nil
+	}
+	return NewParams(), fmt.Errorf("cannot convert %v to Params", v)
+}
+
+func isMap(v interface{}) bool {
+	_, ok := v.(map[string]interface{})
+	return ok
+}
+
+// Set sets a parameter.
+func (p Params) Set(path string, v interface{}) {
+	parts := strings.Split(path, ".")
+	m := p
+	for i := 0; i < len(parts)-1; i++ {
+		part := parts[i]
+		value, ok := m[part]
+		// If the part key doesn't exist yet or is primitive type, create it.
+		if !ok || !isMap(value) {
+			p := make(map[string]interface{})
+			m[part] = p
+			m = p
+			continue
+		}
+		// Continue through the chain of maps
+		m = m[part].(map[string]interface{})
+	}
+
+	// Internal types are only primitive types and maps, not Params. Convert Params
+	// to map[string]interface{}.
+	if p, ok := v.(Params); ok {
+		v = map[string]interface{}(p)
+	}
+
+	key := parts[len(parts)-1]
+	m[key] = v
+}
+
+// SetBool sets a boolean parameter.
+func (p Params) SetBool(path string, b bool) {
+	p.Set(path, b)
+}
+
+// SetNumber sets a number parameter.
+func (p Params) SetNumber(path string, f float64) {
+	p.Set(path, f)
+}
+
+// SetString sets a string parameter.
+func (p Params) SetString(path string, s string) {
+	p.Set(path, s)
+}
+
+// SetObject sets an object parameter.
+func (p Params) SetObject(path string, o Params) {
+	p.Set(path, o)
+}
+
+// Merge merges two parameter stores.
+func (p Params) Merge(a Params) {
+	for k, v := range a {
+		// k isn't in the original map, set it.
+		if _, ok := p[k]; !ok {
+			p[k] = v
+			continue
+		}
+		dst := p[k]
+
+		// Both original and incoming values are maps.
+		dstMap, dstOk := dst.(map[string]interface{})
+		srcMap, srcOk := v.(map[string]interface{})
+		if dstOk && srcOk {
+			Params(dstMap).Merge(srcMap)
+			continue
+		}
+
+		// Otherwise, source overrides destination
+		p[k] = v
+	}
+}
+
+func (p Params) String() string {
+	s, _ := json.MarshalIndent(p, "", " ")
+	return string(s)
+}

--- a/pkg/std/params_test.go
+++ b/pkg/std/params_test.go
@@ -1,0 +1,112 @@
+package std
+
+import (
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func p(s string) Params {
+	r := strings.NewReader(s)
+	params, err := NewParamsFromJSON(r)
+	if err != nil {
+		log.Fatal(s, err)
+	}
+	return params
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		o        Params
+		path     string
+		valid    bool
+		expected interface{}
+	}{
+		{map[string]interface{}{}, "foo.bar", false, nil},
+		{p(`{ "foo": 2 }`), "foo.bar", false, nil},
+		{p(`{ "foo": { "bar": 2 } }`), "foo.bar", true, float64(2)},
+		{p(`{ "foo": { "bar": "baz" } }`), "foo.bar", true, "baz"},
+		{p(`{ "foo": { "bar": { "baz": 3 } } }`), "foo.bar", true, p(`{ "baz": 3 }`)},
+		{p(`{ "xxx": "yyy", "foo": { "bar": { "baz": 3 } } }`), "foo.bar", true, p(`{ "baz": 3 }`)},
+	}
+
+	for _, test := range tests {
+		v, err := test.o.Get(test.path)
+		if test.valid {
+			assert.NoError(t, err)
+		} else {
+			assert.Error(t, err)
+		}
+		assert.Equal(t, test.expected, v)
+	}
+}
+
+func TestTypedGet(t *testing.T) {
+	params := p(`{ "xxx": "yyy", "foo": { "bar": { "baz": 3 }, "boolean": true } }`)
+
+	vBool, err := params.GetBool("foo.boolean")
+	assert.NoError(t, err)
+	assert.Equal(t, true, vBool)
+
+	vNumber, err := params.GetNumber("foo.bar.baz")
+	assert.NoError(t, err)
+	assert.Equal(t, float64(3), vNumber)
+
+	vString, err := params.GetString("xxx")
+	assert.NoError(t, err)
+	assert.Equal(t, "yyy", vString)
+	_, err = params.GetString("foo.bar.baz")
+	assert.Error(t, err)
+
+	vObject, err := params.GetObject("foo.bar")
+	assert.NoError(t, err)
+	assert.Equal(t, p(`{ "baz": 3 }`), vObject)
+
+}
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		o        Params
+		path     string
+		value    interface{}
+		expected Params
+	}{
+		{p(`{}`), "foo", float64(2), p(`{ "foo": 2 }`)},
+		{p(`{}`), "foo", "bar", p(`{ "foo": "bar" }`)},
+		{p(`{}`), "foo", true, p(`{ "foo": true }`)},
+		{p(`{}`), "foo", p(`{ "bar": "baz" } `), p(`{ "foo": { "bar": "baz" } }`)},
+		{p(`{ "foo": { "xxx": 42 } }`), "foo.yyy", p(`{ "bar": "baz" } `), p(`{ "foo": { "xxx": 42, "yyy": { "bar": "baz" } } }`)},
+	}
+
+	for _, test := range tests {
+		test.o.Set(test.path, test.value)
+		assert.Equal(t, test.expected, test.o)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		a, b     Params
+		expected Params
+	}{
+		{NewParams(), NewParams(), NewParams()},
+		{map[string]interface{}{}, map[string]interface{}{}, map[string]interface{}{}},
+		{map[string]interface{}{}, map[string]interface{}{"foo": 1}, map[string]interface{}{"foo": 1}},
+		{map[string]interface{}{}, map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}},
+		{map[string]interface{}{"foo": 1}, map[string]interface{}{}, map[string]interface{}{"foo": 1}},
+		{map[string]interface{}{"foo": "bar"}, map[string]interface{}{}, map[string]interface{}{"foo": "bar"}},
+
+		{p(`{ "foo": 1 } `), p(`{ "foo": { "bar": "baz" } }`), p(`{"foo": { "bar": "baz" } }`)},
+		{p(`{ "foo": 1, "orig": "xxx" } `), p(`{ "foo": { "bar": "baz" } }`), p(`{"foo": { "bar": "baz" }, "orig": "xxx" }`)},
+		{p(`{ "foo": { "rab": "zab" }, "orig": "xxx" } `), p(`{ "foo": { "bar": "baz" } }`), p(`{"foo": { "bar": "baz", "rab": "zab" }, "orig": "xxx" }`)},
+		{p(`{ "foo": { "bar": "baz" } }`), p(`{ "foo": { "rab": "zab" }, "orig": "xxx" } `), p(`{"foo": { "bar": "baz", "rab": "zab" }, "orig": "xxx" }`)},
+	}
+
+	for _, test := range tests {
+		test.a.Merge(test.b)
+		assert.Equal(t, test.expected, test.a)
+	}
+
+}

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -23,6 +23,8 @@ type sender interface {
 
 // ExecuteOptions global input parameters to the standards library.
 type ExecuteOptions struct {
+	// Parameters is a structured set of input parameters.
+	Parameters Params
 	// OutputDirectory is a directory used by any file producing functions as the
 	// base directory to output files to.
 	OutputDirectory string
@@ -76,6 +78,21 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		args := __std.ListArgs{}
 		args.Init(union.Bytes, union.Pos)
 		return directoryListing(string(args.Path()))
+
+	case __std.ArgsParamArgs:
+		args := __std.ParamArgs{}
+		args.Init(union.Bytes, union.Pos)
+
+		json := param(options.Parameters, __std.ParamType(args.Type()), string(args.Path()))
+
+		b := flatbuffers.NewBuilder(512)
+		jsonOffset := b.CreateString(string(json))
+		__std.ParamResponseStart(b)
+		__std.ParamResponseAddJson(b, jsonOffset)
+		responseOffset := __std.ParamResponseEnd(b)
+		b.Finish(responseOffset)
+		return b.FinishedBytes()
+
 	default:
 		log.Fatalf("unknown Message (%d)", message.ArgsType())
 		return nil

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -83,7 +83,7 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		args := __std.ParamArgs{}
 		args.Init(union.Bytes, union.Pos)
 
-		json := param(options.Parameters, __std.ParamType(args.Type()), string(args.Path()))
+		json := param(options.Parameters, __std.ParamType(args.Type()), string(args.Path()), string(args.DefaultValue()))
 
 		b := flatbuffers.NewBuilder(512)
 		jsonOffset := b.CreateString(string(json))

--- a/run.go
+++ b/run.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/jkcfg/jk/pkg/deferred"
 	"github.com/jkcfg/jk/pkg/resolve"
@@ -12,6 +15,7 @@ import (
 
 	v8 "github.com/ry/v8worker2"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var runCmd = &cobra.Command{
@@ -21,12 +25,72 @@ var runCmd = &cobra.Command{
 	Run:   run,
 }
 
+type paramsOption struct {
+	params *std.Params
+	kind   std.ParamKind
+}
+
+func (p *paramsOption) String() string {
+	return ""
+}
+
+func (p *paramsOption) Set(s string) error {
+	parts := strings.Split(s, "=")
+	if len(parts) != 2 {
+		return errors.New("input parameters are of the form name=value")
+	}
+	path := parts[0]
+	v := parts[1]
+
+	switch p.kind {
+	case std.ParamKindBoolean:
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("could not parse '%s' as a boolean", v)
+		}
+		p.params.SetBool(path, b)
+	case std.ParamKindNumber:
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse '%s' as a float64", v)
+		}
+		p.params.SetNumber(path, n)
+	case std.ParamKindString:
+		p.params.SetString(path, v)
+	case std.ParamKindObject:
+		o, err := std.NewParamsFromJSON(strings.NewReader(v))
+		if err != nil {
+			return fmt.Errorf("could not parse JSON '%s': %v", v, err)
+		}
+		p.params.SetObject(path, o)
+	}
+
+	return nil
+}
+
+func (p *paramsOption) Type() string {
+	return "name=value"
+}
+
 var runOptions struct {
 	outputDirectory string
+	parameters      std.Params
+}
+
+func parameters(kind std.ParamKind) pflag.Value {
+	return &paramsOption{
+		params: &runOptions.parameters,
+		kind:   kind,
+	}
 }
 
 func init() {
+	runOptions.parameters = std.NewParams()
 	runCmd.PersistentFlags().StringVarP(&runOptions.outputDirectory, "output-directory", "o", "", "where to output generated files")
+	runCmd.PersistentFlags().Var(parameters(std.ParamKindBoolean), "pb", "boolean input parameter")
+	runCmd.PersistentFlags().Var(parameters(std.ParamKindNumber), "pn", "number input parameter")
+	runCmd.PersistentFlags().Var(parameters(std.ParamKindString), "ps", "string input parameter")
+	runCmd.PersistentFlags().Var(parameters(std.ParamKindObject), "po", "object input parameter")
 	jk.AddCommand(runCmd)
 }
 
@@ -43,6 +107,7 @@ type exec struct {
 
 func (e *exec) onMessageReceived(msg []byte) []byte {
 	return std.Execute(msg, e.worker, std.ExecuteOptions{
+		Parameters:      runOptions.parameters,
 		OutputDirectory: runOptions.outputDirectory,
 	})
 }

--- a/run.go
+++ b/run.go
@@ -90,7 +90,9 @@ func (p *paramsOption) setFromCommandline(s string) error {
 		if err != nil {
 			return fmt.Errorf("could not parse JSON '%s': %v", v, err)
 		}
-		p.params.SetObject(path, o)
+		params := std.NewParams()
+		params.SetObject(path, o)
+		p.params.Merge(params)
 	}
 
 	return nil

--- a/run.go
+++ b/run.go
@@ -25,9 +25,18 @@ var runCmd = &cobra.Command{
 	Run:   run,
 }
 
+type paramKind int
+
+const (
+	paramKindBoolean paramKind = iota
+	paramKindNumber
+	paramKindString
+	paramKindObject
+)
+
 type paramsOption struct {
 	params *std.Params
-	kind   std.ParamKind
+	kind   paramKind
 }
 
 func (p *paramsOption) String() string {
@@ -43,21 +52,21 @@ func (p *paramsOption) Set(s string) error {
 	v := parts[1]
 
 	switch p.kind {
-	case std.ParamKindBoolean:
+	case paramKindBoolean:
 		b, err := strconv.ParseBool(v)
 		if err != nil {
 			return fmt.Errorf("could not parse '%s' as a boolean", v)
 		}
 		p.params.SetBool(path, b)
-	case std.ParamKindNumber:
+	case paramKindNumber:
 		n, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			return fmt.Errorf("could not parse '%s' as a float64", v)
 		}
 		p.params.SetNumber(path, n)
-	case std.ParamKindString:
+	case paramKindString:
 		p.params.SetString(path, v)
-	case std.ParamKindObject:
+	case paramKindObject:
 		o, err := std.NewParamsFromJSON(strings.NewReader(v))
 		if err != nil {
 			return fmt.Errorf("could not parse JSON '%s': %v", v, err)
@@ -77,7 +86,7 @@ var runOptions struct {
 	parameters      std.Params
 }
 
-func parameters(kind std.ParamKind) pflag.Value {
+func parameters(kind paramKind) pflag.Value {
 	return &paramsOption{
 		params: &runOptions.parameters,
 		kind:   kind,
@@ -87,10 +96,10 @@ func parameters(kind std.ParamKind) pflag.Value {
 func init() {
 	runOptions.parameters = std.NewParams()
 	runCmd.PersistentFlags().StringVarP(&runOptions.outputDirectory, "output-directory", "o", "", "where to output generated files")
-	runCmd.PersistentFlags().Var(parameters(std.ParamKindBoolean), "pb", "boolean input parameter")
-	runCmd.PersistentFlags().Var(parameters(std.ParamKindNumber), "pn", "number input parameter")
-	runCmd.PersistentFlags().Var(parameters(std.ParamKindString), "ps", "string input parameter")
-	runCmd.PersistentFlags().Var(parameters(std.ParamKindObject), "po", "object input parameter")
+	runCmd.PersistentFlags().Var(parameters(paramKindBoolean), "pb", "boolean input parameter")
+	runCmd.PersistentFlags().Var(parameters(paramKindNumber), "pn", "number input parameter")
+	runCmd.PersistentFlags().Var(parameters(paramKindString), "ps", "string input parameter")
+	runCmd.PersistentFlags().Var(parameters(paramKindObject), "po", "object input parameter")
 	jk.AddCommand(runCmd)
 }
 

--- a/std/__std.fbs
+++ b/std/__std.fbs
@@ -2,6 +2,7 @@ include "__std_Deferred.fbs";
 include "__std_FileSystem.fbs";
 include "__std_Write.fbs";
 include "__std_Read.fbs";
+include "__std_Param.fbs";
 
 namespace __std;
 
@@ -13,6 +14,7 @@ union Args {
     // FileSystem
     FileInfoArgs,
     ListArgs,
+    ParamArgs,
 }
 
 table Message {

--- a/std/__std_Param.fbs
+++ b/std/__std_Param.fbs
@@ -1,0 +1,17 @@
+namespace __std;
+
+enum ParamType : byte {
+    Boolean,
+    Number,
+    String,
+    Object,
+}
+
+table ParamArgs {
+  path: string;
+  type: ParamType;
+}
+
+table ParamResponse {
+  json: string;
+}

--- a/std/__std_Param.fbs
+++ b/std/__std_Param.fbs
@@ -10,6 +10,10 @@ enum ParamType : byte {
 table ParamArgs {
   path: string;
   type: ParamType;
+  // defaultValue is the JSON representation of the default value. This is
+  // currently used for object parameters only so we can merge the provided
+  // parameters with the default object.
+  defaultValue: string;
 }
 
 table ParamResponse {

--- a/std/std.js
+++ b/std/std.js
@@ -3,6 +3,7 @@ import { log } from 'std_log';
 import { Format, write } from 'std_write';
 import { Encoding, read } from 'std_read';
 import { info, dir } from 'std_fs';
+import { param } from 'std_param';
 
 export default {
   print,
@@ -13,4 +14,5 @@ export default {
   read,
   info,
   dir,
+  param,
 };

--- a/std/std_param.js
+++ b/std/std_param.js
@@ -1,0 +1,51 @@
+import flatbuffers from 'flatbuffers';
+import { __std } from '__std_generated';
+
+function getParameter(type, path, defaultValue) {
+  const builder = new flatbuffers.Builder(512);
+  const pathOffset = builder.createString(path);
+
+  __std.ParamArgs.startParamArgs(builder);
+  __std.ParamArgs.addPath(builder, pathOffset);
+  __std.ParamArgs.addType(builder, type);
+  const argsOffset = __std.ParamArgs.endParamArgs(builder);
+
+  __std.Message.startMessage(builder);
+  __std.Message.addArgsType(builder, __std.Args.ParamArgs);
+  __std.Message.addArgs(builder, argsOffset);
+  const messageOffset = __std.Message.endMessage(builder);
+  builder.finish(messageOffset);
+
+  const bytes = V8Worker2.send(builder.asArrayBuffer());
+
+  const buf = new flatbuffers.ByteBuffer(new Uint8Array(bytes));
+  const resp = __std.ParamResponse.getRootAsParamResponse(buf);
+  const v = JSON.parse(resp.json());
+  if (v == null) {
+    return defaultValue;
+  }
+  return v;
+}
+
+function getBoolean(path, defaultValue) {
+  return getParameter(__std.ParamType.Boolean, path, defaultValue);
+}
+
+function getNumber(path, defaultValue) {
+  return getParameter(__std.ParamType.Number, path, defaultValue);
+}
+
+function getString(path, defaultValue) {
+  return getParameter(__std.ParamType.String, path, defaultValue);
+}
+
+function getObject(path, defaultValue) {
+  return getParameter(__std.ParamType.Object, path, defaultValue);
+}
+
+export const param = {
+  Boolean: getBoolean,
+  Number: getNumber,
+  String: getString,
+  Object: getObject,
+};

--- a/std/std_param.js
+++ b/std/std_param.js
@@ -4,10 +4,15 @@ import { __std } from '__std_generated';
 function getParameter(type, path, defaultValue) {
   const builder = new flatbuffers.Builder(512);
   const pathOffset = builder.createString(path);
+  const isObject = type === __std.ParamType.Object;
+  const defaultValueOffset = isObject && builder.createString(JSON.stringify(defaultValue));
 
   __std.ParamArgs.startParamArgs(builder);
   __std.ParamArgs.addPath(builder, pathOffset);
   __std.ParamArgs.addType(builder, type);
+  if (isObject) {
+    __std.ParamArgs.addDefaultValue(builder, defaultValueOffset);
+  }
   const argsOffset = __std.ParamArgs.endParamArgs(builder);
 
   __std.Message.startMessage(builder);

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,8 @@ $ jk run -o test-$testname.expected test-$testname.js
 
   In that file, special variables can be used for convenience:
 
+  **%f**: the name of test js file
+
   **%t**: the name of the test
 
   **%d**: the name of the recommended output directory (ie. `test-%testname.got`)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -150,6 +150,9 @@ func runTest(t *testing.T, test *test) {
 		_, ok := err.(*exec.ExitError)
 		assert.True(t, ok)
 	} else {
+		if err != nil {
+			fmt.Print(string(output))
+		}
 		assert.NoError(t, err)
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -43,6 +43,10 @@ type test struct {
 	file string // name of the test-*.js test file
 }
 
+func (t *test) jsFile() string {
+	return t.file
+}
+
 func (t *test) name() string {
 	return t.file[:len(t.file)-3]
 }
@@ -69,6 +73,7 @@ func (t *test) parseCmd(line string) []string {
 	replacer := strings.NewReplacer(
 		"%d", t.outputDir(),
 		"%t", t.name(),
+		"%f", t.jsFile(),
 	)
 	// Replace special strings
 	for i := range parts {

--- a/tests/test-params-from-file.js
+++ b/tests/test-params-from-file.js
@@ -1,0 +1,19 @@
+import std from 'std';
+
+const b = std.param.Boolean('myBoolean', false);
+const n = std.param.Number('myNumber', 3.14);
+const s = std.param.String('myString', 'foo');
+const o = std.param.Object('myObject', {
+  s: 'bar',
+  b: true,
+  o: {
+    xxx: 'yyy',
+  },
+});
+
+std.log({
+  myBoolean: b,
+  myNumber: n,
+  myString: s,
+  myObject: o,
+});

--- a/tests/test-params-from-file.js.cmd
+++ b/tests/test-params-from-file.js.cmd
@@ -1,0 +1,1 @@
+jk run --parameters %t.json %f

--- a/tests/test-params-from-file.js.expected
+++ b/tests/test-params-from-file.js.expected
@@ -2,10 +2,13 @@
   "myBoolean": true,
   "myNumber": 2,
   "myObject": {
+    "b": true,
     "message": "success",
     "o": {
-      "foo": "bar"
-    }
+      "foo": "bar",
+      "xxx": "yyy"
+    },
+    "s": "bar"
   },
   "myString": "success"
 }

--- a/tests/test-params-from-file.js.expected
+++ b/tests/test-params-from-file.js.expected
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params-from-file.json
+++ b/tests/test-params-from-file.json
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params-merge-object.js
+++ b/tests/test-params-merge-object.js
@@ -1,0 +1,19 @@
+import std from 'std';
+
+const b = std.param.Boolean('myBoolean', false);
+const n = std.param.Number('myNumber', 3.14);
+const s = std.param.String('myString', 'foo');
+const o = std.param.Object('myObject', {
+  s: 'bar',
+  b: true,
+  o: {
+    xxx: 'yyy',
+  },
+});
+
+std.log({
+  myBoolean: b,
+  myNumber: n,
+  myString: s,
+  myObject: o,
+});

--- a/tests/test-params-merge-object.js.cmd
+++ b/tests/test-params-merge-object.js.cmd
@@ -1,0 +1,1 @@
+jk run --parameters %t.json --po myObject.o={"xxx":"yyy"} %f

--- a/tests/test-params-merge-object.js.expected
+++ b/tests/test-params-merge-object.js.expected
@@ -1,0 +1,12 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar",
+      "xxx": "yyy"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params-merge-object.js.expected
+++ b/tests/test-params-merge-object.js.expected
@@ -2,11 +2,13 @@
   "myBoolean": true,
   "myNumber": 2,
   "myObject": {
+    "b": true,
     "message": "success",
     "o": {
       "foo": "bar",
       "xxx": "yyy"
-    }
+    },
+    "s": "bar"
   },
   "myString": "success"
 }

--- a/tests/test-params-merge-object.json
+++ b/tests/test-params-merge-object.json
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params-override.js
+++ b/tests/test-params-override.js
@@ -1,0 +1,19 @@
+import std from 'std';
+
+const b = std.param.Boolean('myBoolean', false);
+const n = std.param.Number('myNumber', 3.14);
+const s = std.param.String('myString', 'foo');
+const o = std.param.Object('myObject', {
+  s: 'bar',
+  b: true,
+  o: {
+    xxx: 'yyy',
+  },
+});
+
+std.log({
+  myBoolean: b,
+  myNumber: n,
+  myString: s,
+  myObject: o,
+});

--- a/tests/test-params-override.js.cmd
+++ b/tests/test-params-override.js.cmd
@@ -1,0 +1,1 @@
+jk run --parameters %t.json --pn myNumber=12 %f

--- a/tests/test-params-override.js.expected
+++ b/tests/test-params-override.js.expected
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 12,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params-override.js.expected
+++ b/tests/test-params-override.js.expected
@@ -2,10 +2,13 @@
   "myBoolean": true,
   "myNumber": 12,
   "myObject": {
+    "b": true,
     "message": "success",
     "o": {
-      "foo": "bar"
-    }
+      "foo": "bar",
+      "xxx": "yyy"
+    },
+    "s": "bar"
   },
   "myString": "success"
 }

--- a/tests/test-params-override.json
+++ b/tests/test-params-override.json
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -1,0 +1,19 @@
+import std from 'std';
+
+const b = std.param.Boolean('myBoolean', false);
+const n = std.param.Number('myNumber', 2.0);
+const s = std.param.String('myString', 'foo');
+const o = std.param.Object('myObject', {
+  s: 'bar',
+  b: true,
+  o: {
+    xxx: 'yyy',
+  },
+});
+
+std.log({
+  myBoolean: b,
+  myNumber: n,
+  myString: s,
+  myObject: o,
+});

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -17,3 +17,23 @@ std.log({
   myString: s,
   myObject: o,
 });
+
+// Test default values are shining through when the parameters aren't
+// specified.
+const bD = std.param.Boolean('myBooleanD', false);
+const nD = std.param.Number('myNumberD', 3.14);
+const sD = std.param.String('myStringD', 'foo');
+const oD = std.param.Object('myObjectD', {
+  s: 'bar',
+  b: true,
+  o: {
+    xxx: 'yyy',
+  },
+});
+
+std.log({
+  myBoolean: bD,
+  myNumber: nD,
+  myString: sD,
+  myObject: oD,
+});

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -1,7 +1,7 @@
 import std from 'std';
 
 const b = std.param.Boolean('myBoolean', false);
-const n = std.param.Number('myNumber', 2.0);
+const n = std.param.Number('myNumber', 3.14);
 const s = std.param.String('myString', 'foo');
 const o = std.param.Object('myObject', {
   s: 'bar',

--- a/tests/test-params.js.cmd
+++ b/tests/test-params.js.cmd
@@ -1,0 +1,1 @@
+jk run --pb myBoolean=true --pn myNumber=2.0 --ps myString=success --po myObject={"message":"success","o":{"foo":"bar"}} %f

--- a/tests/test-params.js.expected
+++ b/tests/test-params.js.expected
@@ -9,3 +9,15 @@
   },
   "myString": "success"
 }
+{
+  "myBoolean": false,
+  "myNumber": 3.14,
+  "myObject": {
+    "b": true,
+    "o": {
+      "xxx": "yyy"
+    },
+    "s": "bar"
+  },
+  "myString": "foo"
+}

--- a/tests/test-params.js.expected
+++ b/tests/test-params.js.expected
@@ -2,10 +2,13 @@
   "myBoolean": true,
   "myNumber": 2,
   "myObject": {
+    "b": true,
     "message": "success",
     "o": {
-      "foo": "bar"
-    }
+      "foo": "bar",
+      "xxx": "yyy"
+    },
+    "s": "bar"
   },
   "myString": "success"
 }

--- a/tests/test-params.js.expected
+++ b/tests/test-params.js.expected
@@ -1,0 +1,11 @@
+{
+  "myBoolean": true,
+  "myNumber": 2,
+  "myObject": {
+    "message": "success",
+    "o": {
+      "foo": "bar"
+    }
+  },
+  "myString": "success"
+}


### PR DESCRIPTION
This PR introduces script input parameters through a new std API: `std.param`. To define a new parameter one writes:

```
const version = std.param.String("version", "0.1.0");
std.print(version);
```

The user can provide a new value from the command line:
```
$ jk run --ps version=1.0.0 script.js
```

Or from a json file with the `-p` option.

Input parameters are in fact organised as a big JSON object, and can be addressed by their path, eg. `"global.version` is the parameter:

```
{
  ...
  "global": {
    ...
    "version": "xxx",
    ...
  },
  ...
}
```

Fixes: #18 