### PR TITLE
std: User rollup + terser + prettier to produce std.js

### DIFF
--- a/std/.prettierrc
+++ b/std/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/std/package-lock.json
+++ b/std/package-lock.json
@@ -1221,6 +1221,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
@@ -1498,9 +1504,9 @@
       }
     },
     "terser": {
-      "version": "3.10.11",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.11.tgz",
-      "integrity": "sha512-iruZ7j14oBbRYJC5cP0/vTU7YOWjN+J1ZskEGoF78tFzXdkK2hbCL/3TRZN8XB+MuvFhvOHMp7WkOCBO4VEL5g==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
+      "integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
       "dev": true,
       "requires": {
         "commander": "~2.17.1",

--- a/std/package.json
+++ b/std/package.json
@@ -5,7 +5,7 @@
   "main": "std.js",
   "scripts": {
     "lint": "eslint std*.js",
-    "build": "mkdir -p build && rollup -c | terser --mangle --module > build/std.js",
+    "build": "mkdir -p build && rollup -c > build/std.js | terser --compress defaults=false,dead_code --module | prettier --stdin-filepath std.js > build/std.js",
     "test": "npm run lint"
   },
   "repository": {
@@ -27,9 +27,10 @@
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
+    "prettier": "^1.15.3",
     "rollup": "^0.67.0",
     "rollup-plugin-includepaths": "^0.2.3",
-    "terser": "^3.10.11"
+    "terser": "^3.14.1"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Using terser has the unfortunate side-effect to produce a one-line std.js which
makes exceptions that happen in std print a gigantic mangled line.

We now use terser for its dead-code elimination pass and use prettier to
reformat the result.

Exceptions now look like:

```
$ cat test-std-exception.js
import std from 'std';
std.read(undefined);

$ jk run test-std-exception.js
std:1031
    while (i < s.length) {
                 ^
TypeError: Cannot read property 'length' of undefined
    at flatbuffers.Builder.createString (std:1031:18)
    at Object.read (std:1393:29)
    at test-std-exception.js:3:5
```