### PR TITLE
Use resolved path when resolving relative imports

### DIFF
--- a/pkg/resolve/file_importer.go
+++ b/pkg/resolve/file_importer.go
@@ -12,7 +12,7 @@ type FileImporter struct {
 }
 
 // Import implements importer.
-func (fi *FileImporter) Import(basePath, specifier, referrer string) ([]byte, []string) {
+func (fi *FileImporter) Import(basePath, specifier, referrer string) ([]byte, string, []string) {
 	var candidates []string
 
 	path := specifier
@@ -27,7 +27,7 @@ func (fi *FileImporter) Import(basePath, specifier, referrer string) ([]byte, []
 			candidates = append(candidates, path+".js")
 			path = filepath.Join(path, "index.js")
 		case err != nil:
-			return nil, candidates
+			return nil, "", candidates
 		default:
 			path = path + ".js"
 		}
@@ -37,11 +37,11 @@ func (fi *FileImporter) Import(basePath, specifier, referrer string) ([]byte, []
 
 	// TODO don't allow climbing out of the base directory with '../../...'
 	if _, err := os.Stat(path); err != nil {
-		return nil, candidates
+		return nil, "", candidates
 	}
 	codeBytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return codeBytes, candidates
+	return codeBytes, path, candidates
 }

--- a/pkg/resolve/npm_test.go
+++ b/pkg/resolve/npm_test.go
@@ -14,7 +14,7 @@ func TestNodeModuleImport(t *testing.T) {
 
 	test := func(name, base, path string) {
 		t.Run(name, func(t *testing.T) {
-			bytes, candidates := node.Import(base, path, "stdin")
+			bytes, path, candidates := node.Import(base, path, "stdin")
 			if bytes == nil {
 				t.Error("did not resolve", path)
 				println("candidates:")

--- a/pkg/resolve/npm_test.go
+++ b/pkg/resolve/npm_test.go
@@ -19,7 +19,7 @@ func TestNodeModuleImport(t *testing.T) {
 				t.Error("did not resolve", path)
 				println("candidates:")
 				for _, c := range candidates {
-					println("  ", c)
+					println("  ", c.Path, c.Rule)
 				}
 			}
 		})

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -52,7 +52,7 @@ func NewResolver(loader Loader, basePath string, importers ...Importer) *Resolve
 func (r Resolver) ResolveModule(specifier, referrer string) int {
 	// The first importer that resolves the specifier wins.
 	var resolvedPath, source string
-	var candidates []string
+	var candidates []Candidate
 
 	for _, importer := range r.importers {
 		data, path, considered := importer.Import(r.base, specifier, referrer)
@@ -69,7 +69,7 @@ func (r Resolver) ResolveModule(specifier, referrer string) int {
 		if len(candidates) > 0 {
 			fmt.Fprintf(os.Stderr, "candidates considered:\n")
 			for _, candidate := range candidates {
-				fmt.Fprintf(os.Stderr, "    %s\n", candidate)
+				fmt.Fprintf(os.Stderr, "    %s (%s)\n", candidate.Path, candidate.Rule)
 			}
 		}
 		return 1

--- a/pkg/resolve/static_importer.go
+++ b/pkg/resolve/static_importer.go
@@ -7,9 +7,9 @@ type StaticImporter struct {
 }
 
 // Import implements importer.
-func (si *StaticImporter) Import(basePath, specifier, referrer string) ([]byte, []string) {
+func (si *StaticImporter) Import(basePath, specifier, referrer string) ([]byte, string, []string) {
 	if si.Specifier == specifier {
-		return si.Source, nil
+		return si.Source, specifier, []string{specifier}
 	}
-	return nil, nil
+	return nil, "", []string{specifier}
 }

--- a/pkg/resolve/static_importer.go
+++ b/pkg/resolve/static_importer.go
@@ -1,5 +1,9 @@
 package resolve
 
+const (
+	staticRule = "built-in"
+)
+
 // StaticImporter is an importer mapping an import specifier to a static string.
 type StaticImporter struct {
 	Specifier string
@@ -7,9 +11,10 @@ type StaticImporter struct {
 }
 
 // Import implements importer.
-func (si *StaticImporter) Import(basePath, specifier, referrer string) ([]byte, string, []string) {
+func (si *StaticImporter) Import(basePath, specifier, referrer string) ([]byte, string, []Candidate) {
+	candidate := []Candidate{{specifier, staticRule}}
 	if si.Specifier == specifier {
-		return si.Source, specifier, []string{specifier}
+		return si.Source, specifier, candidate
 	}
-	return nil, "", []string{specifier}
+	return nil, "", candidate
 }

--- a/pkg/resolve/types.go
+++ b/pkg/resolve/types.go
@@ -11,5 +11,8 @@ type Loader interface {
 
 // Importer is a object resolving a import to actual JS code.
 type Importer interface {
-	Import(basePath, specifier, referrer string) (data []byte, candidates []string)
+	// Resolve a specifier (e.g., `my-module/foo') to a specific path
+	// and file contents. Also returns a list of the interpretations
+	// of the specifier attempted, including that returned.
+	Import(basePath, specifier, referrer string) (data []byte, path string, candidates []string)
 }

--- a/pkg/resolve/types.go
+++ b/pkg/resolve/types.go
@@ -9,10 +9,17 @@ type Loader interface {
 	LoadModule(scriptName string, code string, resolve v8.ModuleResolverCallback) error
 }
 
+// Candidate is a path that was considered when resolving an import,
+// and the explanation (resolution rule) for why it was connsidered.
+type Candidate struct {
+	Path string
+	Rule string
+}
+
 // Importer is a object resolving a import to actual JS code.
 type Importer interface {
 	// Resolve a specifier (e.g., `my-module/foo') to a specific path
 	// and file contents. Also returns a list of the interpretations
 	// of the specifier attempted, including that returned.
-	Import(basePath, specifier, referrer string) (data []byte, path string, candidates []string)
+	Import(basePath, specifier, referrer string) (data []byte, path string, candidates []Candidate)
 }

--- a/tests/node_modules/testcase/index.js
+++ b/tests/node_modules/testcase/index.js
@@ -1,0 +1,1 @@
+export default "test message goes here";

--- a/tests/node_modules/testcase/indirect.js
+++ b/tests/node_modules/testcase/indirect.js
@@ -1,0 +1,2 @@
+import msg from './test3';
+export default msg;

--- a/tests/node_modules/testcase/package.json
+++ b/tests/node_modules/testcase/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "testcase",
+  "version": "1.0.0",
+  "description": "Test case for importing NPM modules",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/node_modules/testcase/subdir/package.json
+++ b/tests/node_modules/testcase/subdir/package.json
@@ -1,0 +1,3 @@
+{
+  "module": "test4.js"
+}

--- a/tests/node_modules/testcase/subdir/test4.js
+++ b/tests/node_modules/testcase/subdir/test4.js
@@ -1,0 +1,1 @@
+export default "four tests are we";

--- a/tests/node_modules/testcase/submodule.js
+++ b/tests/node_modules/testcase/submodule.js
@@ -1,0 +1,1 @@
+export default "test number two";

--- a/tests/node_modules/testcase/test3.js
+++ b/tests/node_modules/testcase/test3.js
@@ -1,0 +1,1 @@
+export default 'The third test';

--- a/tests/test-npm-imports.expected/test1.json
+++ b/tests/test-npm-imports.expected/test1.json
@@ -1,0 +1,1 @@
+"test message goes here"

--- a/tests/test-npm-imports.expected/test2.json
+++ b/tests/test-npm-imports.expected/test2.json
@@ -1,0 +1,1 @@
+"test number two"

--- a/tests/test-npm-imports.expected/test3.json
+++ b/tests/test-npm-imports.expected/test3.json
@@ -1,0 +1,1 @@
+"The third test"

--- a/tests/test-npm-imports.expected/test4.json
+++ b/tests/test-npm-imports.expected/test4.json
@@ -1,0 +1,1 @@
+"four tests are we"

--- a/tests/test-npm-imports.js
+++ b/tests/test-npm-imports.js
@@ -1,0 +1,8 @@
+import std from '@jkcfg/std';
+
+import msg1 from 'testcase'; // node_modules/testcase/index.js
+std.write(msg1, 'test1.json');
+
+import msg2 from 'testcase/submodule'; // node_modules/testcase/submodule.js
+std.write(msg2, 'test2.json');
+

--- a/tests/test-npm-imports.js
+++ b/tests/test-npm-imports.js
@@ -1,3 +1,7 @@
+/* eslint "import/no-unresolved": [2, { ignore: ['.*'] }] */
+// ^ switch this rule in eslint off, since module resolution is what's under test here.
+/* eslint "import/first": [0] */
+/* eslint "import/newline-after-import": [0] */
 import std from '@jkcfg/std';
 
 import msg1 from 'testcase'; // node_modules/testcase/index.js

--- a/tests/test-npm-imports.js
+++ b/tests/test-npm-imports.js
@@ -6,3 +6,8 @@ std.write(msg1, 'test1.json');
 import msg2 from 'testcase/submodule'; // node_modules/testcase/submodule.js
 std.write(msg2, 'test2.json');
 
+import msg3 from 'testcase/indirect'; // node_modules/testcase/indirect.js imports ./test3
+std.write(msg3, 'test3.json');
+
+import msg4 from 'testcase/subdir'; // node_modules/testcase/subdir/package.json specifies test4.js in its `module` field
+std.write(msg4, 'test4.json');


### PR DESCRIPTION
Prior to npm module resolution, the specifier for a module and the
file path had a direct relationship, and it was a reasonable
approximation to make base/specifier the new base for recursive
imports.

However, npm modules can be resolved to paths that don't correspond
closely with the specifier; so, explicitly return the filesystem path
from `Import` and use that to resolve recursive imports.

(Another way to do this would be to take the top path from the candidates list, and assume the contract that it must be the successful path (if bytes is not empty).)