### PR TITLE
Supply a fallback promise rejection handler

### DIFF
--- a/run.go
+++ b/run.go
@@ -36,6 +36,13 @@ const (
 	paramKindObject
 )
 
+const errorHandler = `
+function onerror(msg, src, line, col, err) {
+  V8Worker2.print("Promise rejected at", src, line + ":" + col);
+  V8Worker2.print(err.stack);
+}
+`
+
 type paramsOption struct {
 	params *std.Params
 	kind   paramKind
@@ -163,6 +170,10 @@ func run(cmd *cobra.Command, args []string) {
 	filename := args[0]
 	input, err := ioutil.ReadFile(filename)
 	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := worker.Load("errorHandler", errorHandler); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
V8Worker2 will look for a global called `onerror`; so load one before
starting.

Also: without intervention, errors that come from the "deferred"
system (when the runtime does something for you and returns the result
later) will have a helpful error message (because we pass it back to
JS), but a meaningless stack trace (because it starts where control
re-enters JS, i.e., at `recv`). To make it a bit more useful, capture
the stack trace when entering code that asks for a deferred value, and
transplant it to any eventual error.