### PR TITLE
build: Make git describe consider lightweight tags too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: jk
 
-VERSION := $(shell git describe)
+VERSION := $(shell git describe --tags)
 
 jk: pkg/__std/lib/assets_vfsdata.go
 	GO111MODULE=on go build -o $@ -ldflags "-X main.Version=$(VERSION)"


### PR DESCRIPTION
Unfortunately, the tags created with the UI aren't annotated (ie. created with
-a), so git descibe wasn't taking them into account, showing the version still
as a 0.2.0-...