### PR TITLE
consolidate print and log

### DIFF
--- a/std/shim/std.ts
+++ b/std/shim/std.ts
@@ -1,4 +1,3 @@
-function print(...args: any[]): void { };
 function log(value: any): void { };
 
 enum Format {
@@ -29,5 +28,5 @@ interface ReadOptions {
 function read(path: string, options?: ReadOptions): Promise<any> { return Promise.resolve({}) };
 
 export default {
-  print, log, Format, write, read,
+  log, Format, write, read,
 };

--- a/std/std.js
+++ b/std/std.js
@@ -1,4 +1,3 @@
-import { print } from 'std_print';
 import { log } from 'std_log';
 import { Format, write } from 'std_write';
 import { Encoding, read } from 'std_read';
@@ -6,7 +5,6 @@ import { info, dir } from 'std_fs';
 import { param } from 'std_param';
 
 export default {
-  print,
   log,
   Format,
   write,

--- a/std/std_print.js
+++ b/std/std_print.js
@@ -1,7 +1,0 @@
-function print(...args) {
-  V8Worker2.print(args);
-}
-
-export {
-  print,
-};

--- a/tests/test-import-script-not-in-cwd.js.expected
+++ b/tests/test-import-script-not-in-cwd.js.expected
@@ -1,1 +1,1 @@
-"success!"
+success!

--- a/tests/test-log.js.expected
+++ b/tests/test-log.js.expected
@@ -1,5 +1,5 @@
 1.2
-"foo"
+foo
 null
 {
   "foo": 1.2,

--- a/tests/test-std-ts.js.expected
+++ b/tests/test-std-ts.js.expected
@@ -1,4 +1,4 @@
+success
+success
 "success"
-"success"
-"success"
-"success"
+success

--- a/tests/test-std-ts.js.expected
+++ b/tests/test-std-ts.js.expected
@@ -1,4 +1,3 @@
-success
 "success"
 "success"
 "success"

--- a/tests/test-std-ts/test.ts
+++ b/tests/test-std-ts/test.ts
@@ -1,6 +1,5 @@
 import std from 'std';
 
-std.print('success');
 std.log('success');
 std.write('success', '');
 std.write('success', '', { format: std.Format.JSON, indent: 2, override: false });

--- a/tests/test-write.expected/test-write-json-string.json
+++ b/tests/test-write.expected/test-write-json-string.json
@@ -1,0 +1,1 @@
+"success"

--- a/tests/test-write.js
+++ b/tests/test-write.js
@@ -15,3 +15,6 @@ std.write(o, 'test-write-override.json');
 std.write(o, 'test-write-override-no-file.json', { override: false });
 std.write({ ...o, foo: { ...o.foo, number: 1.3 } }, 'test-write-override.json', { override: false });
 std.write({ ...o, foo: { ...o.foo, string: 'yourstring' } }, 'test-write-override.json', { override: true });
+
+// Test writing a string in a JSON file does print the string as a JSON document.
+std.write('success', 'test-write-json-string.json');


### PR DESCRIPTION
The current behaviour of `log` printing JSON values isn't ideal when printing astring. We have:
    
    std.log('foo') => "foo"
    
We special case strings so we don't end up with the double quotes. It's really confusing and hard to work around.
  
A last detail: when asked to write JSON though, we make sure to still print strings as JSON values!

Fixes: #96 