### PR TITLE
Introduce exec option for root read directory

### DIFF
--- a/pkg/resolve/npm.go
+++ b/pkg/resolve/npm.go
@@ -73,7 +73,7 @@ func (n *NodeModulesImporter) Import(basePath, specifier, referrer string) ([]by
 	if strings.HasPrefix(specifier, "./") || strings.HasPrefix(specifier, "../") {
 		return loadAsPath(filepath.Join(basePath, specifier))
 	}
-	return loadAsModule(specifier, filepath.Dir(basePath))
+	return loadAsModule(specifier, basePath)
 }
 
 var moduleExtensions = []string{".mjs", ".js"}

--- a/pkg/std/read.go
+++ b/pkg/std/read.go
@@ -49,6 +49,24 @@ func readerByPath(path string) readFunc {
 	return readJSON
 }
 
+// ReadBase represents the base directory for paths; it also serves
+// the purpose of being the top-most directory for reads, in the case
+// of paths including '..', or absolute paths.
+type ReadBase struct {
+	Path string
+}
+
+func (r ReadBase) Read(path string, format __std.Format, encoding __std.Encoding) ([]byte, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(r.Path, path)
+	}
+	_, err := filepath.Rel(r.Path, path)
+	if err != nil {
+		return nil, err
+	}
+	return read(path, format, encoding)
+}
+
 func read(path string, format __std.Format, encoding __std.Encoding) ([]byte, error) {
 	// TODO(michael): optionally (by default) check that the file is "here or down"
 	var reader readFunc = readRaw

--- a/pkg/std/read.go
+++ b/pkg/std/read.go
@@ -68,7 +68,6 @@ func (r ReadBase) Read(path string, format __std.Format, encoding __std.Encoding
 }
 
 func read(path string, format __std.Format, encoding __std.Encoding) ([]byte, error) {
-	// TODO(michael): optionally (by default) check that the file is "here or down"
 	var reader readFunc = readRaw
 
 	if encoding == __std.EncodingJSON {

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -32,6 +32,8 @@ type ExecuteOptions struct {
 	// OutputDirectory is a directory used by any file producing functions as the
 	// base directory to output files to.
 	OutputDirectory string
+	// Root is topmost directory under which file reads are allowed
+	Root ReadBase
 }
 
 func toBool(b byte) bool {
@@ -75,7 +77,7 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		// for now, treat everything as a file read from a local path
 		// (which will only fail in the resolution, and can't be
 		// cancelled).
-		ser := deferred.Register(func() ([]byte, error) { return read(string(args.Url()), args.Format(), args.Encoding()) }, sendFunc(res.SendBytes))
+		ser := deferred.Register(func() ([]byte, error) { return options.Root.Read(string(args.Url()), args.Format(), args.Encoding()) }, sendFunc(res.SendBytes))
 		return deferredResponse(ser)
 	case __std.ArgsFileInfoArgs:
 		args := __std.FileInfoArgs{}

--- a/run.go
+++ b/run.go
@@ -152,7 +152,8 @@ func runArgs(cmd *cobra.Command, args []string) error {
 }
 
 type exec struct {
-	worker *v8.Worker
+	worker     *v8.Worker
+	workingDir string
 }
 
 func (e *exec) onMessageReceived(msg []byte) []byte {
@@ -160,11 +161,16 @@ func (e *exec) onMessageReceived(msg []byte) []byte {
 		Verbose:         runOptions.verbose,
 		Parameters:      runOptions.parameters,
 		OutputDirectory: runOptions.outputDirectory,
+		Root:            std.ReadBase{e.workingDir},
 	})
 }
 
 func run(cmd *cobra.Command, args []string) {
-	engine := &exec{}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	engine := &exec{workingDir: cwd}
 	worker := v8.New(engine.onMessageReceived)
 	engine.worker = worker
 	filename := args[0]

--- a/tests/input.json
+++ b/tests/input.json
@@ -1,0 +1,1 @@
+"this is from input.json in a directory given with --input-directory"

--- a/tests/input/input.json
+++ b/tests/input/input.json
@@ -1,0 +1,1 @@
+"this is from input.json in the same directory as test.js"

--- a/tests/input/test.js
+++ b/tests/input/test.js
@@ -1,0 +1,9 @@
+// This test checks that a read path is resolved relative to an input
+// directory. It's used from more than one test -- other tests may be
+// given as .cmd files invoking this file.
+
+import std from '@jkcfg/std';
+
+// the location of this file will differ depending on the
+// `--input-directory` given (or not given) to jk run
+std.read('input.json').then(std.log)

--- a/tests/node_modules/testcase/node_modules/vendored/index.js
+++ b/tests/node_modules/testcase/node_modules/vendored/index.js
@@ -1,0 +1,1 @@
+export default "vendored module";

--- a/tests/node_modules/testcase/vendor.js
+++ b/tests/node_modules/testcase/vendor.js
@@ -1,0 +1,3 @@
+import msg from 'vendored';
+
+export default msg;

--- a/tests/test-input-directory-elsewhere.js.cmd
+++ b/tests/test-input-directory-elsewhere.js.cmd
@@ -1,0 +1,1 @@
+jk run --input-directory . input/test.js

--- a/tests/test-input-directory-elsewhere.js.expected
+++ b/tests/test-input-directory-elsewhere.js.expected
@@ -1,0 +1,1 @@
+this is from input.json in a directory given with --input-directory

--- a/tests/test-input-directory-scriptdir.js.cmd
+++ b/tests/test-input-directory-scriptdir.js.cmd
@@ -1,0 +1,1 @@
+jk run input/test.js

--- a/tests/test-input-directory-scriptdir.js.expected
+++ b/tests/test-input-directory-scriptdir.js.expected
@@ -1,0 +1,1 @@
+this is from input.json in the same directory as test.js

--- a/tests/test-npm-imports.expected/test5.json
+++ b/tests/test-npm-imports.expected/test5.json
@@ -1,0 +1,1 @@
+"vendored module"

--- a/tests/test-npm-imports.js
+++ b/tests/test-npm-imports.js
@@ -4,18 +4,24 @@
 /* eslint "import/newline-after-import": [0] */
 import std from '@jkcfg/std';
 
-import msg1 from 'testcase'; // node_modules/testcase/index.js
+// node_modules/testcase/index.js
+import msg1 from 'testcase';
 std.write(msg1, 'test1.json');
 
-import msg2 from 'testcase/submodule'; // node_modules/testcase/submodule.js
+// node_modules/testcase/submodule.js
+import msg2 from 'testcase/submodule';
 std.write(msg2, 'test2.json');
 
-import msg3 from 'testcase/indirect'; // node_modules/testcase/indirect.js imports ./test3
+// node_modules/testcase/indirect.js imports ./test3
+import msg3 from 'testcase/indirect';
 std.write(msg3, 'test3.json');
 
-import msg4 from 'testcase/subdir'; // node_modules/testcase/subdir/package.json specifies test4.js in its `module` field
+// node_modules/testcase/subdir/package.json specifies test4.js in its
+// `module` field
+import msg4 from 'testcase/subdir';
 std.write(msg4, 'test4.json');
 
+// node_modules/testcase/vendor.js imports from 'vendor', which is to
+// be found at node_modules/testcase/node_modules/vendored/index.js
 import msg5 from 'testcase/vendor';
-// node_modules/testcase/vendor.js imports from 'vendor', which is to be found at node_modules/testcase/node_modules/vendored/index.js
 std.write(msg5, 'test5.json');

--- a/tests/test-npm-imports.js
+++ b/tests/test-npm-imports.js
@@ -15,3 +15,7 @@ std.write(msg3, 'test3.json');
 
 import msg4 from 'testcase/subdir'; // node_modules/testcase/subdir/package.json specifies test4.js in its `module` field
 std.write(msg4, 'test4.json');
+
+import msg5 from 'testcase/vendor';
+// node_modules/testcase/vendor.js imports from 'vendor', which is to be found at node_modules/testcase/node_modules/vendored/index.js
+std.write(msg5, 'test5.json');

--- a/tests/test-std-ts.js.cmd
+++ b/tests/test-std-ts.js.cmd
@@ -1,3 +1,3 @@
 npm install --prefix %t
 npm run build --prefix %t
-jk run %t/test.js
+jk run -i . %t/test.js


### PR DESCRIPTION
This adds an option for the runtime to tell it
the base directory for reads. The idea is that relative paths will be
interpreted with respect to the base path.

This opens the way to providing a directory _other_ than the current
working directory -- e.g., that of the script being run.

If we are being strictly hermetic, absolute paths should be
disallowed. For the minute, I've just restricted them to paths that
happen to be under the base path.

The two flags to control this are

 * --directory,-C meaning use the given directory as the base; and,
 * --use-script-dir meaning use the directory the script is in as the base.

It occurs to me that another formulation is to have just `--directory,-C` and otherwise assume the script dir is the base dir. In that case, if you want to run a script that comes with its own data, you just name the script; and if you want to run a script with your own data, you use `-C` (even if it's `-C .`).

The `-C` comes from Unix tradition (e.g., `make`; `git` also uses it), meaning "first change the working directory to ...".  To "properly" support it, we might consider using the directory given as the output directory as well, unless otherwise instructed.