### PR TITLE
jk: Silence errors and usage coming from cobra

### DIFF
--- a/jk.go
+++ b/jk.go
@@ -9,8 +9,10 @@ import (
 )
 
 var jk = cobra.Command{
-	Use:   "jk",
-	Short: "jk helps you maintain configuration",
+	Use:           "jk",
+	Short:         "jk helps you maintain configuration",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func main() {


### PR DESCRIPTION
With RunE functions, cobra prints out the err and usage string itself before
handing over the error to us. We want to be in full control of what is
diplayed, though and currently we print the error twice:

```
    $ jk run -p fo
    Error: invalid argument "fo" for "-p, --parameter" flag: input parameters are of the form name=value
    Usage:
      jk run [flags]

    Flags:
      -h, --help                      help for run
      -i, --input-directory string    where to find files read in the script; if not set, the directory containing the     script is used
      -o, --output-directory string   where to output generated files
      -p, --parameter name=value      boolean input parameter
      -f, --parameters filename       load parameters from a JSON file
      -v, --verbose                   verbose output

    invalid argument "fo" for "-p, --parameter" flag: input parameters are of the form name=value
```
After this change, we just print the last line (which we could tune maybe :)