### PR TITLE
param: Fix NPE when not specifying a default Object value

### DIFF
--- a/std/std_param.js
+++ b/std/std_param.js
@@ -5,7 +5,9 @@ function getParameter(type, path, defaultValue) {
   const builder = new flatbuffers.Builder(512);
   const pathOffset = builder.createString(path);
   const isObject = type === __std.ParamType.Object;
-  const defaultValueOffset = isObject && builder.createString(JSON.stringify(defaultValue));
+  const defaultValueOffset = isObject
+    && defaultValue !== undefined
+    && builder.createString(JSON.stringify(defaultValue));
 
   __std.ParamArgs.startParamArgs(builder);
   __std.ParamArgs.addPath(builder, pathOffset);

--- a/tests/test-params-issue-122.js
+++ b/tests/test-params-issue-122.js
@@ -1,0 +1,4 @@
+import std from 'std';
+
+const values = std.param.Object('values');
+std.log(values);

--- a/tests/test-params-issue-122.js.cmd
+++ b/tests/test-params-issue-122.js.cmd
@@ -1,0 +1,1 @@
+jk run -p values.foo=success %f

--- a/tests/test-params-issue-122.js.expected
+++ b/tests/test-params-issue-122.js.expected
@@ -1,0 +1,3 @@
+{
+  "foo": "success"
+}


### PR DESCRIPTION
We had a bug for Object parameters specifically. For objects, we deep merge the
object default value with param sub-subtree that the user already provided and
so we need to send the object default value to the go side.

We were serializing the object default value as a JSON string for that but
without checking the user did specify a default object.

Fixes: #122