### PR TITLE
Stream formats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/text v0.3.0
-	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.2.1
 )
 
 // go modules need a special branch with a few commits (that have been proposed upstream)

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -85,7 +85,7 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		// for now, treat everything as a file read from a local path
 		// (which will only fail in the resolution, and can't be
 		// cancelled).
-		ser := deferred.Register(func() ([]byte, error) { return options.Root.Read(string(args.Url()), args.Format(), args.Encoding()) }, sendFunc(res.SendBytes))
+		ser := deferred.Register(func() ([]byte, error) { return options.Root.Read(string(args.Path()), args.Format(), args.Encoding()) }, sendFunc(res.SendBytes))
 		return deferredResponse(ser)
 	case __std.ArgsFileInfoArgs:
 		args := __std.FileInfoArgs{}

--- a/pkg/std/write.go
+++ b/pkg/std/write.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jkcfg/jk/pkg/__std"
 
 	"github.com/ghodss/yaml"
+	yamlclassic "gopkg.in/yaml.v2"
 )
 
 type closer func()
@@ -61,6 +62,32 @@ func writeYAML(w io.Writer, value []byte, indent int) {
 		log.Fatalf("writeYAML: %s", err)
 	}
 	w.Write(y)
+}
+
+func writeYAMLStream(w io.Writer, v []byte, indent int) {
+	var values []interface{}
+	if err := json.Unmarshal(v, &values); err != nil {
+		log.Fatalf("writeYAMLStream: %s", err)
+	}
+	encoder := yamlclassic.NewEncoder(w)
+	for _, item := range values {
+		if err := encoder.Encode(item); err != nil {
+			log.Fatalf("writeYAMLStream: %s", err)
+		}
+	}
+}
+
+func writeJSONStream(w io.Writer, v []byte, indent int) {
+	var values []interface{}
+	if err := json.Unmarshal(v, &values); err != nil {
+		log.Fatalf("writeJSONStream: %s", err)
+	}
+	encoder := json.NewEncoder(w)
+	for _, item := range values {
+		if err := encoder.Encode(item); err != nil {
+			log.Fatalf("writeJSONStream: %s", err)
+		}
+	}
 }
 
 func writeRaw(w io.Writer, value []byte, _ int) {
@@ -119,8 +146,12 @@ func write(value []byte, path string, format __std.Format, indent int, overwrite
 		out = writerFuncFromPath(path)
 	case __std.FormatJSON:
 		out = writeJSON(jsonString)
+	case __std.FormatJSONStream:
+		out = writeJSONStream
 	case __std.FormatYAML:
 		out = writeYAML
+	case __std.FormatYAMLStream:
+		out = writeYAMLStream
 	case __std.FormatRaw:
 		out = writeRaw
 	default:

--- a/std/__std_Format.fbs
+++ b/std/__std_Format.fbs
@@ -5,4 +5,6 @@ enum Format : byte {
     JSON,
     YAML,
     Raw,
+    YAMLStream,
+    JSONStream
 }

--- a/std/__std_Read.fbs
+++ b/std/__std_Read.fbs
@@ -16,7 +16,7 @@ enum Encoding : byte {
 }
 
 table ReadArgs {
-  url: string;
+  path: string;
   timeout: uint;
   encoding: Encoding;
   format: Format;

--- a/std/std_read.js
+++ b/std/std_read.js
@@ -16,9 +16,9 @@ const stringify = bytes => String.fromCodePoint(...uint8ToUint16Array(bytes));
 // with the contents at the path, or rejected.
 function read(path, { encoding = Encoding.JSON, format = Format.Auto } = {}) {
   const builder = new flatbuffers.Builder(512);
-  const urlOffset = builder.createString(path);
+  const pathOffset = builder.createString(path);
   __std.ReadArgs.startReadArgs(builder);
-  __std.ReadArgs.addUrl(builder, urlOffset);
+  __std.ReadArgs.addPath(builder, pathOffset);
   __std.ReadArgs.addEncoding(builder, encoding);
   __std.ReadArgs.addFormat(builder, format);
   const argsOffset = __std.ReadArgs.endReadArgs(builder);

--- a/tests/test-jsonstream.js
+++ b/tests/test-jsonstream.js
@@ -1,0 +1,4 @@
+import std from 'std';
+
+const value = std.read('./test-jsonstream.js.expected', { format: std.Format.JSONStream });
+value.then(v => std.log(v, { format: std.Format.JSONStream }));

--- a/tests/test-jsonstream.js.expected
+++ b/tests/test-jsonstream.js.expected
@@ -1,0 +1,3 @@
+{"bar":{"baz":1}}
+"literal string"
+[9,8,7]

--- a/tests/test-yamlstream.js
+++ b/tests/test-yamlstream.js
@@ -1,0 +1,4 @@
+import std from 'std';
+
+const value = std.read('./test-yamlstream.js.expected', { format: std.Format.YAMLStream });
+value.then(v => std.log(v, { format: std.Format.YAMLStream }));

--- a/tests/test-yamlstream.js.expected
+++ b/tests/test-yamlstream.js.expected
@@ -1,0 +1,10 @@
+baz:
+- 1
+- 2
+- 3
+foo: bar
+--- literal string
+---
+- 9
+- 8
+- 7


### PR DESCRIPTION
Adds the formats `YAMLStream` and `JSONStream`, and supports reading and writing them.

Addresses #93.