### PR TITLE
Use canonical module specifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/flatbuffers v1.10.0
+	github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/ry/v8worker2 v0.0.0-20180926144945-e3fa6c4d602b
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca
 	github.com/spf13/cobra v0.0.3
@@ -14,7 +14,3 @@ require (
 	golang.org/x/text v0.3.0
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
-
-// go modules need a special branch with a few commits (that have been proposed upstream)
-//replace github.com/ry/v8worker2 => github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099
-replace github.com/ry/v8worker2 => github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 )
 
 // go modules need a special branch with a few commits (that have been proposed upstream)
-replace github.com/ry/v8worker2 => github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099
+//replace github.com/ry/v8worker2 => github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099
+replace github.com/ry/v8worker2 => github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/jkcfg/v8worker2 v0.0.0-20181103131220-163e7fd126a2 h1:SsNwIj868+EIEnw
 github.com/jkcfg/v8worker2 v0.0.0-20181103131220-163e7fd126a2/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099 h1:CKxqDomswaJteVLxmp5Lo02zy3+33QGSs3J0eh+Po3U=
 github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
+github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720 h1:YBgCfrSk4xZOH//PIvVw80/n5BkIPrwWoik275XUqtg=
+github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 h1:SWV2fHctRpRrp49VXJ6UZja7gU9QLHwRpIPBN89SKEo=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,12 @@ github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099 h1:CKxqDomswaJteVL
 github.com/jkcfg/v8worker2 v0.0.0-20190118163300-ec91674d0099/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720 h1:YBgCfrSk4xZOH//PIvVw80/n5BkIPrwWoik275XUqtg=
 github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
+github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2 h1:yroXZIO0q4uBioF+qxfrstz58/0kCKGJsBFd1Vd2OYg=
+github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ry/v8worker2 v0.0.0-20190118154056-6857a7739bc2 h1:nvqxIeI0eVhPV4d3UubaTiadSnAha1DaqMOBN0E3kqg=
+github.com/ry/v8worker2 v0.0.0-20190118154056-6857a7739bc2/go.mod h1:BdjqPPLlLw26j9NdhD0cQVJL7JvzCk6iWLsdy8NzbpQ=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 h1:SWV2fHctRpRrp49VXJ6UZja7gU9QLHwRpIPBN89SKEo=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca h1:3fECS8atRjByijiI8yYiuwLwQ2ZxXobW7ua/8GRB3pI=

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -49,7 +49,7 @@ func NewResolver(loader Loader, basePath string, importers ...Importer) *Resolve
 
 // ResolveModule imports the specifier from an import statement located in the
 // referrer module.
-func (r Resolver) ResolveModule(specifier, referrer string) int {
+func (r Resolver) ResolveModule(specifier, referrer string) (string, int) {
 	// The first importer that resolves the specifier wins.
 	var resolvedPath, source string
 	var candidates []Candidate
@@ -72,14 +72,14 @@ func (r Resolver) ResolveModule(specifier, referrer string) int {
 				fmt.Fprintf(os.Stderr, "    %s (%s)\n", candidate.Path, candidate.Rule)
 			}
 		}
-		return 1
+		return "", 1
 	}
 
 	resolver := r
 	resolver.base = filepath.Dir(resolvedPath)
-	if err := r.loader.LoadModule(specifier, source, resolver.ResolveModule); err != nil {
+	if err := r.loader.LoadModule(resolvedPath, source, resolver.ResolveModule); err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
-		return 1
+		return "", 1
 	}
-	return 0
+	return resolvedPath, 0
 }

--- a/pkg/resolve/types.go
+++ b/pkg/resolve/types.go
@@ -1,7 +1,7 @@
 package resolve
 
 import (
-	v8 "github.com/ry/v8worker2"
+	v8 "github.com/jkcfg/v8worker2"
 )
 
 // Loader is an object able to load a ES 2015 module.

--- a/run.go
+++ b/run.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jkcfg/jk/pkg/resolve"
 	"github.com/jkcfg/jk/pkg/std"
 
-	v8 "github.com/ry/v8worker2"
+	v8 "github.com/jkcfg/v8worker2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/run.go
+++ b/run.go
@@ -40,6 +40,10 @@ function onerror(msg, src, line, col, err) {
 }
 `
 
+const global = `
+var global = {};
+`
+
 type paramsOption struct {
 	params *std.Params
 	source paramSource
@@ -161,6 +165,9 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	if err := worker.Load("errorHandler", errorHandler); err != nil {
+		log.Fatal(err)
+	}
+	if err := worker.Load("global", global); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Adapts the jk runtime to the slightly changed module resolution in our (jkcfg) v8worker2, after https://github.com/jkcfg/v8worker2/pull/2.