### PR TITLE
params: Add a all() function that returns all defined parameters

### DIFF
--- a/pkg/std/params.go
+++ b/pkg/std/params.go
@@ -64,6 +64,11 @@ func NewParamsFromFile(path string) (Params, error) {
 
 // Get retrieves a parameter.
 func (p Params) Get(path string) (interface{}, error) {
+	// "" has the special meaning of "all of p"
+	if path == "" {
+		return p, nil
+	}
+
 	parts := strings.Split(path, ".")
 	m := p
 	for i, part := range parts {

--- a/pkg/std/params_test.go
+++ b/pkg/std/params_test.go
@@ -41,6 +41,8 @@ func TestGet(t *testing.T) {
 		{p(`{ "foo": 2 }`), "foo.bar", false, nil},
 		{p(`{ "foo": { "bar": 2 } }`), "foo.bar", true, float64(2)},
 		{p(`{ "foo": { "bar": "baz" } }`), "foo.bar", true, "baz"},
+		// "" means the bag of parameters
+		{p(`{ "foo": { "bar": "baz" } }`), "", true, p(`{ "foo": { "bar": "baz" } }`)},
 		{p(`{ "foo": { "bar": { "baz": 3 } } }`), "foo.bar", true, p(`{ "baz": 3 }`)},
 		{p(`{ "xxx": "yyy", "foo": { "bar": { "baz": 3 } } }`), "foo.bar", true, p(`{ "baz": 3 }`)},
 	}
@@ -77,6 +79,12 @@ func TestTypedGet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, p(`{ "baz": 3 }`), vObject)
 
+	// "" means all parameters. Only valid with GetObject though.
+	vAll, err := params.GetObject("")
+	assert.NoError(t, err)
+	assert.Equal(t, params, vAll)
+	_, err = params.GetBool("")
+	assert.Error(t, err)
 }
 
 func TestCoercion(t *testing.T) {

--- a/std/std_param.js
+++ b/std/std_param.js
@@ -67,7 +67,12 @@ function getObject(path, defaultValue) {
   return getParameter(__std.ParamType.Object, path, defaultValue);
 }
 
+function all() {
+  return getObject('');
+}
+
 export const param = {
+  all,
   Boolean: getBoolean,
   Number: getNumber,
   String: getString,

--- a/tests/test-params-all.js
+++ b/tests/test-params-all.js
@@ -1,0 +1,4 @@
+import std from 'std';
+
+const { message } = std.param.all();
+std.log(message);

--- a/tests/test-params-all.js.cmd
+++ b/tests/test-params-all.js.cmd
@@ -1,0 +1,1 @@
+jk run -f success.json %f

--- a/tests/test-params-all.js.expected
+++ b/tests/test-params-all.js.expected
@@ -1,0 +1,1 @@
+success


### PR DESCRIPTION
Fixes: #124