### PR TITLE
tests: Make logging the resources deterministic

### DIFF
--- a/tests/test-module-resource.js
+++ b/tests/test-module-resource.js
@@ -2,5 +2,4 @@ import std from '@jkcfg/std';
 import resource1 from './test-module-resource/resource';
 import resource2 from './test-module-resource/submodule/resource';
 
-resource1.then(std.log);
-resource2.then(std.log);
+Promise.all([resource1, resource2]).then(resources => resources.forEach(std.log));


### PR DESCRIPTION
The termination of promises is non deterministic, in particular it means we
can't rely on std.log for resource1 to be called before std.log for resource2.

Instead, let's wait for all promises to be resolved and than cycle though their
values to log them to stdout.