### PR TITLE
Provide module-relative fs.dir and fs.info as well

### DIFF
--- a/pkg/std/readbase.go
+++ b/pkg/std/readbase.go
@@ -1,0 +1,45 @@
+package std
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResourceBaser is an interface for getting base paths for resources.
+type ResourceBaser interface {
+	ResourceBase(string) (string, bool)
+}
+
+// ReadBase resolves relative paths, and resources (module-relative
+// paths). Reads outside the base are forbidden and will return an
+// error.
+type ReadBase struct {
+	Path      string
+	Resources ResourceBaser
+}
+
+func (r ReadBase) getPath(path, module string) (string, string, error) {
+	base := r.Path
+	if module != "" {
+		modBase, ok := r.Resources.ResourceBase(module)
+		if !ok {
+			return "", "", fmt.Errorf("read from unknown module")
+		}
+		base = modBase
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(base, path)
+	}
+
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", "", fmt.Errorf("reads outside base path forbidden")
+	}
+
+	return base, rel, nil
+}

--- a/pkg/std/resource.go
+++ b/pkg/std/resource.go
@@ -50,11 +50,19 @@ import std from '@jkcfg/std';
 
 const module = %q;
 
-function resource(path, {...rest} = {}) {
+function read(path, {...rest} = {}) {
   return std.read(path, {...rest, module});
 }
 
-export default resource;
+function dir(path) {
+  return std.dir(path, { module });
+}
+
+function info(path) {
+  return std.info(path, { module });
+}
+
+export { read, dir, info };
 `
 	return []byte(fmt.Sprintf(code, moduleHash)), "resource:" + basePath
 }

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -92,14 +92,15 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		module := string(args.Module())
 		ser := deferred.Register(func() ([]byte, error) { return options.Root.Read(path, args.Format(), args.Encoding(), module) }, sendFunc(res.SendBytes))
 		return deferredResponse(ser)
+
 	case __std.ArgsFileInfoArgs:
 		args := __std.FileInfoArgs{}
 		args.Init(union.Bytes, union.Pos)
-		return fileInfo(string(args.Path()))
+		return options.Root.FileInfo(string(args.Path()), string(args.Module()))
 	case __std.ArgsListArgs:
 		args := __std.ListArgs{}
 		args.Init(union.Bytes, union.Pos)
-		return directoryListing(string(args.Path()))
+		return options.Root.DirectoryListing(string(args.Path()), string(args.Module()))
 
 	case __std.ArgsParamArgs:
 		args := __std.ParamArgs{}

--- a/std/__std_FileSystem.fbs
+++ b/std/__std_FileSystem.fbs
@@ -16,10 +16,12 @@ table Directory {
 
 table FileInfoArgs {
     path: string;
+    module: string;
 }
 
 table ListArgs {
     path: string;
+    module: string;
 }
 
 union FileSystemRetval {

--- a/std/std_fs.js
+++ b/std/std_fs.js
@@ -17,11 +17,19 @@ class Directory {
   }
 }
 
-function info(path) {
+function info(path, { module } = {}) {
   const builder = new flatbuffers.Builder(512);
   const pathOffset = builder.createString(path);
+  let moduleOffset = 0;
+  if (module !== undefined) {
+    moduleOffset = builder.createString(module);
+  }
+
   __std.FileInfoArgs.startFileInfoArgs(builder);
   __std.FileInfoArgs.addPath(builder, pathOffset);
+  if (module !== undefined) {
+    __std.FileInfoArgs.addModule(builder, moduleOffset);
+  }
   const argsOffset = __std.FileInfoArgs.endFileInfoArgs(builder);
 
   __std.Message.startMessage(builder);
@@ -49,11 +57,19 @@ function info(path) {
   }
 }
 
-function dir(path) {
+function dir(path, { module } = {}) {
   const builder = new flatbuffers.Builder(512);
   const pathOffset = builder.createString(path);
+  let moduleOffset = 0;
+  if (module !== undefined) {
+    moduleOffset = builder.createString(module);
+  }
+
   __std.ListArgs.startListArgs(builder);
   __std.ListArgs.addPath(builder, pathOffset);
+  if (module !== undefined) {
+    __std.ListArgs.addModule(builder, moduleOffset);
+  }
   const argsOffset = __std.ListArgs.endListArgs(builder);
 
   __std.Message.startMessage(builder);

--- a/tests/test-module-resource.js
+++ b/tests/test-module-resource.js
@@ -1,5 +1,6 @@
 import std from '@jkcfg/std';
 import resource1 from './test-module-resource/resource';
 import resource2 from './test-module-resource/submodule/resource';
+import contents from './test-module-resource/fs';
 
-Promise.all([resource1, resource2]).then(resources => resources.forEach(std.log));
+Promise.all([resource1, resource2, contents]).then(resources => resources.forEach(std.log));

--- a/tests/test-module-resource.js.expected
+++ b/tests/test-module-resource.js.expected
@@ -4,3 +4,21 @@
 {
   "module": "sub"
 }
+{
+  "dir": {
+    "files": [
+      {
+        "isdir": false,
+        "name": "info",
+        "path": "dir/info"
+      }
+    ],
+    "name": "dir",
+    "path": "dir"
+  },
+  "info": {
+    "isdir": false,
+    "name": "info",
+    "path": "dir/info"
+  }
+}

--- a/tests/test-module-resource/dir/info
+++ b/tests/test-module-resource/dir/info
@@ -1,0 +1,1 @@
+A file for the purpose of requesting file info

--- a/tests/test-module-resource/fs.js
+++ b/tests/test-module-resource/fs.js
@@ -1,0 +1,3 @@
+import { dir, info } from '@jkcfg/std/resource';
+
+export default Promise.resolve({ dir: dir('dir'), info: info('dir/info') });

--- a/tests/test-module-resource/resource.js
+++ b/tests/test-module-resource/resource.js
@@ -1,3 +1,3 @@
-import resource from '@jkcfg/std/resource';
+import { read } from '@jkcfg/std/resource';
 
-export default resource('value.json');
+export default read('value.json');

--- a/tests/test-module-resource/submodule/resource.js
+++ b/tests/test-module-resource/submodule/resource.js
@@ -1,3 +1,3 @@
-import resource from '@jkcfg/std/resource';
+import { read } from '@jkcfg/std/resource';
 
-export default resource('values.json');
+export default read('values.json');


### PR DESCRIPTION
```
import { read, dir, info } from '@jkcfg/std/resource';
```

This tidies up the implementation of `dir` and `info` a bit as well:

 - they now obey the input directory constraint
 - names and paths in the output are more consistent
