### PR TITLE
feat(cli): autocomplete

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -19,6 +19,11 @@ To configure your bash shell to load completions for each session add to your ba
 
 # ~/.bashrc or ~/.profile
 . <(jk completion)
+
+If you want to use zsh instead, do the following:
+
+$ jk completion zsh > _jk
+Then move _jk into $fpath and run compinit.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		shell := "bash"

--- a/completion.go
+++ b/completion.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:       "completion [shell]",
+	Args:      cobra.OnlyValidArgs,
+	ValidArgs: []string{"bash", "zsh"},
+	Short:     "Generate shell completions",
+	Long: `To load completion run
+
+. <(jk completion)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+. <(jk completion)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		shell := "bash"
+		if len(args) > 0 {
+			shell = args[0]
+		}
+
+		switch shell {
+		case "zsh":
+			jk.GenZshCompletion(os.Stdout)
+		default:
+			jk.GenBashCompletion(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	jk.AddCommand(completionCmd)
+}

--- a/run.go
+++ b/run.go
@@ -111,7 +111,7 @@ func init() {
 	runCmd.PersistentFlags().VarP(parameters(paramSourceCommandLine), "parameter", "p", "boolean input parameter")
 	parameterFlag := runCmd.PersistentFlags().VarPF(parameters(paramSourceFile), "parameters", "f", "load parameters from a JSON or YAML file")
 	parameterFlag.Annotations = map[string][]string{
-		cobra.BashCompFilenameExt: []string{"json", "yaml", "yml"},
+		cobra.BashCompFilenameExt: {"json", "yaml", "yml"},
 	}
 	jk.AddCommand(runCmd)
 }

--- a/run.go
+++ b/run.go
@@ -108,8 +108,11 @@ func init() {
 	runCmd.PersistentFlags().BoolVarP(&runOptions.verbose, "verbose", "v", false, "verbose output")
 	runCmd.PersistentFlags().StringVarP(&runOptions.outputDirectory, "output-directory", "o", "", "where to output generated files")
 	runCmd.PersistentFlags().StringVarP(&runOptions.inputDirectory, "input-directory", "i", "", "where to find files read in the script; if not set, the directory containing the script is used")
-	runCmd.PersistentFlags().VarP(parameters(paramSourceFile), "parameters", "f", "load parameters from a JSON or YAML file")
 	runCmd.PersistentFlags().VarP(parameters(paramSourceCommandLine), "parameter", "p", "boolean input parameter")
+	parameterFlag := runCmd.PersistentFlags().VarPF(parameters(paramSourceFile), "parameters", "f", "load parameters from a JSON or YAML file")
+	parameterFlag.Annotations = map[string][]string{
+		cobra.BashCompFilenameExt: []string{"json", "yaml", "yml"},
+	}
 	jk.AddCommand(runCmd)
 }
 


### PR DESCRIPTION
This PR adds autocompletion support for `bash` and `zsh`.

### Added Functionality
* Subcommand completion for both shells
* Filename completion for `jk run -f` in bash (`yaml`, `yml`, `json`). Cobra does not seem to support this in `zsh` at the moment.

### Generating completions
* `bash`: `source  <(jk completion)`
* `zsh`: `jk completion zsh > _jk`, then move `_jk` into `$fpath` and run `compinit`.

Closes #113 