### PR TITLE
Bump the go version to 1.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: minimal
 
 env:
   global:
-    - GOVERSION=1.11.2
+    - GOVERSION=1.12.1
     - GOMETALINTER_VERSION=2.0.11
     - GITHUB_RELEASE_VERSION=0.7.2
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When contributing to this repository, please first discuss the change you wish t
 The `jk` executable itself is written in [Go](https://golang.org), but the JavaScript part of this project requires [NodeJS](https://nodejs.org).
 
 **Prerequisites:**
-* `go` 1.11+ (modules support)
+* `go` 1.11.4 or later (modules support)
 * `nodejs`, `npm`
 * `make`
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build v8
-FROM golang:1.11.1 as v8builder
+FROM golang:1.12.1 as v8builder
 RUN apt-get update && apt-get install -y \
     bzip2 \
     libglib2.0-dev \
@@ -11,7 +11,7 @@ RUN cd $GOPATH/src/github.com/jkcfg/v8worker2 \
     && ./build.py
 
 # Build flatbuffer compiler, flatc
-FROM golang:1.11.1 as flatc-builder
+FROM golang:1.12.1 as flatc-builder
 RUN apt-get update && apt-get install -y \
     cmake \
   && rm -rf /var/lib/apt/lists/*
@@ -27,12 +27,12 @@ RUN curl -fsSLO --compressed "https://github.com/google/flatbuffers/archive/v${F
     && rm -rf flatbuffers-${FLATBUFFERS_VERSION}
 
 # Build github-release
-FROM golang:1.11.1 as github-release-builder
+FROM golang:1.12.1 as github-release-builder
 RUN go get github.com/aktau/github-release \
   && cp `go env GOPATH`/bin/github-release /usr/local/bin \
   && rm -rf `go env GOPATH`/src/github.com/aktau/github-release
 
-FROM golang:1.11.1 as fetcher
+FROM golang:1.12.1 as fetcher
 RUN apt-get update && apt-get install -y \
     xz-utils \
   && rm -rf /var/lib/apt/lists/*
@@ -56,7 +56,7 @@ RUN curl -fsSLo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/dow
     && chmod +x /usr/local/bin/gosu
 
 # Our final build image
-FROM golang:1.11.1
+FROM golang:1.12.1
 COPY --from=v8builder /go/src/github.com/jkcfg/v8worker2/v8.pc /usr/local/lib/pkgconfig/
 RUN sed -i \
      -e 's#Cflags: .*#Cflags: -I/usr/local/include/v8#' \

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/google/flatbuffers v1.10.0 h1:oRiOciRvbejW4wxTr/DVVAczyQaxsEONq6NyxhDf3bY=
+github.com/google/flatbuffers v1.10.0 h1:wHCM5N1xsJ3VwePcIpVqnmjAqRXlR44gv4hpGi+/LIw=
 github.com/google/flatbuffers v1.10.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/jkcfg/v8worker2 v0.0.0-20181103131220-163e7fd126a2 h1:SsNwIj868+EIEnwSJT02K5Y3GtGWL64/5Ipy9O0cYXY=
 github.com/jkcfg/v8worker2 v0.0.0-20181103131220-163e7fd126a2/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=


### PR DESCRIPTION
We've had a report from @sh0rez that the go.sum we generate is not compatible with older versions of go. Bump the go version we use to 1.12.1

```
verifying github.com/google/flatbuffers@v1.10.0: checksum mismatch
	downloaded: h1:wHCM5N1xsJ3VwePcIpVqnmjAqRXlR44gv4hpGi+/LIw=
	go.sum:     h1:oRiOciRvbejW4wxTr/DVVAczyQaxsEONq6NyxhDf3bY=
```
- https://github.com/golang/go/issues/27093
- https://github.com/golang/go/issues/27925
- https://github.com/golang/go/issues/29278