### PR TITLE
Resolve files within packages correctly

### DIFF
--- a/pkg/resolve/npm_test.go
+++ b/pkg/resolve/npm_test.go
@@ -39,4 +39,5 @@ func TestNodeModuleImport(t *testing.T) {
 	// In variously nested node_modules locations (i.e., non-relative)
 	test("in a node_modules package, as an index file", "testfiles/", "modfoo")
 	test("in a package, in a sub-directory, then package.json", "testfiles/", "modfoo/lib")
+	test("in a package, in a sub-directory, preferring file to dir", "testfiles/", "modfoo/lib/bar")
 }

--- a/pkg/resolve/testfiles/node_modules/modfoo/lib/bar.js
+++ b/pkg/resolve/testfiles/node_modules/modfoo/lib/bar.js
@@ -1,0 +1,1 @@
+"An arbitrarily-named file within a directory within a package"

--- a/pkg/resolve/testfiles/node_modules/modfoo/lib/bar/notindex.js
+++ b/pkg/resolve/testfiles/node_modules/modfoo/lib/bar/notindex.js
@@ -1,0 +1,1 @@
+"Not an index file, and therefore cannot imported by naming the containing directory"


### PR DESCRIPTION
Briefly: if you have

```
node_modules/
  foo/
    bar.js
    bar/
```

then import `foo/bar` will fail, because the resolver prefers the directory over the file, and can't backtrack once it discovers there's no index in the dir.