### PR TITLE
run: Add an option to emit the list of a script dependencies

### DIFF
--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -1,0 +1,53 @@
+package record
+
+import "encoding/json"
+
+// OperationKind is the name of a recorded operation
+type OperationKind string
+
+// Params are Operation parameters we can record along with an entry.
+type Params map[string]interface{}
+
+const (
+	// ImportFile is a js import from the filesystem (exclude stdlib imports).
+	ImportFile OperationKind = "import-file"
+	// ReadFile is a std.read from the filesystem (exclude reading from stdin).
+	ReadFile OperationKind = "read-file"
+)
+
+// Operation is an entry in the Recording.
+type Operation struct {
+	kind   OperationKind
+	params Params
+}
+
+// MarshalJSON implements json.Marshaler.
+func (o Operation) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	m["kind"] = o.kind
+	for k, v := range o.params {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+// Recorder records Operations. It's designed to be generic, any part of jk can
+// append an operation to the log.
+type Recorder struct {
+	ops []Operation
+}
+
+// Record appends a new operation to the log.
+func (r *Recorder) Record(kind OperationKind, params Params) {
+	r.ops = append(r.ops, Operation{kind: kind, params: params})
+}
+
+// Log retrieves the recording list of operations
+func (r *Recorder) Log() []Operation {
+	return r.ops
+}
+
+// MarshalJSON implements json.Marshaler.
+func (r Recorder) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.ops)
+}

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -11,6 +11,8 @@ type Params map[string]interface{}
 const (
 	// ImportFile is a js import from the filesystem (exclude stdlib imports).
 	ImportFile OperationKind = "import-file"
+	// ParameterFile is a file holding input parameters specified with the -f switch.
+	ParameterFile OperationKind = "parameter-file"
 	// ReadFile is a std.read from the filesystem (exclude reading from stdin).
 	ReadFile OperationKind = "read-file"
 )

--- a/pkg/std/read.go
+++ b/pkg/std/read.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/text/encoding/unicode"
 
 	"github.com/jkcfg/jk/pkg/__std"
+	"github.com/jkcfg/jk/pkg/record"
 
 	"github.com/ghodss/yaml"
 	yamlclassic "gopkg.in/yaml.v2"
@@ -109,7 +110,13 @@ func (r ReadBase) Read(path string, format __std.Format, encoding __std.Encoding
 	if err != nil {
 		return nil, err
 	}
-	return read(filepath.Join(base, path), format, encoding)
+	fullpath := filepath.Join(base, path)
+	if r.Recorder != nil {
+		r.Recorder.Record(record.ReadFile, record.Params{
+			"path": fullpath,
+		})
+	}
+	return read(fullpath, format, encoding)
 }
 
 func read(path string, format __std.Format, encoding __std.Encoding) ([]byte, error) {

--- a/pkg/std/readbase.go
+++ b/pkg/std/readbase.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/jkcfg/jk/pkg/record"
 )
 
 // ResourceBaser is an interface for getting base paths for resources.
@@ -17,6 +19,7 @@ type ResourceBaser interface {
 type ReadBase struct {
 	Path      string
 	Resources ResourceBaser
+	Recorder  *record.Recorder
 }
 
 func (r ReadBase) getPath(path, module string) (string, string, error) {

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -34,6 +34,9 @@ type ExecuteOptions struct {
 	OutputDirectory string
 	// Root is topmost directory under which file reads are allowed
 	Root ReadBase
+	// DryRun instructs standard library functions to not complete operations that
+	// would mutate something (eg. std.write()).
+	DryRun bool
 }
 
 func toBool(b byte) bool {
@@ -74,6 +77,11 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 		if path != "" && options.Verbose {
 			fmt.Printf("wrote %s\n", path)
 		}
+
+		if options.DryRun {
+			break
+		}
+
 		write(args.Value(), path, args.Format(), int(args.Indent()), toBool(args.Overwrite()))
 		return nil
 	case __std.ArgsReadArgs:
@@ -128,8 +136,9 @@ func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
 
 	default:
 		log.Fatalf("unknown Message (%d)", message.ArgsType())
-		return nil
 	}
+
+	return nil
 }
 
 func deferredResponse(s deferred.Serial) []byte {

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ to the results we expect.
 - The test will run with:
 
 ```console
-$ jk run -o test-$testname.expected test-$testname.js
+$ jk run -o test-$testname.got test-$testname.js
 ```
 
 - If the file `test-$testname.js.skip` exists, the test is skipped. This is

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -106,7 +106,7 @@ func (t *test) runWithCmd() (string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		args := t.parseCmd(scanner.Text())
-		cmd := exec.Command(args[0], args[1:]...)
+		cmd := exec.Command("/bin/sh", "-c", strings.Join(args, " "))
 		if err := t.setStdin(cmd); err != nil {
 			return "", err
 		}

--- a/tests/test-run-dependencies.js
+++ b/tests/test-run-dependencies.js
@@ -1,0 +1,5 @@
+import * as std from '@jkcfg/std';
+import { foo } from './test-run-dependencies/failure';
+
+std.log(foo);
+std.read('test-run-dependencies/svc-myapp.yaml');

--- a/tests/test-run-dependencies.js.cmd
+++ b/tests/test-run-dependencies.js.cmd
@@ -1,0 +1,1 @@
+jk run -f %t/params.json -d %t.js | sed 's#^\(.*"path": "\).*\(/jk/tests/.*\)$#\1\2#'

--- a/tests/test-run-dependencies.js.expected
+++ b/tests/test-run-dependencies.js.expected
@@ -1,0 +1,20 @@
+[
+  {
+    "kind": "import-file",
+    "path": "/jk/tests/test-run-dependencies.js",
+    "specifier": "test-run-dependencies.js"
+  },
+  {
+    "kind": "parameter-file",
+    "path": "/jk/tests/test-run-dependencies/params.json"
+  },
+  {
+    "kind": "import-file",
+    "path": "/jk/tests/test-run-dependencies/failure.js",
+    "specifier": "./test-run-dependencies/failure"
+  },
+  {
+    "kind": "read-file",
+    "path": "/jk/tests/test-run-dependencies/svc-myapp.yaml"
+  }
+]

--- a/tests/test-run-dependencies/failure.js
+++ b/tests/test-run-dependencies/failure.js
@@ -1,0 +1,1 @@
+export const foo = 'failure';

--- a/tests/test-run-dependencies/params.json
+++ b/tests/test-run-dependencies/params.json
@@ -1,0 +1,3 @@
+{
+  "name": "success"
+}

--- a/tests/test-run-dependencies/svc-myapp.yaml
+++ b/tests/test-run-dependencies/svc-myapp.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376


### PR DESCRIPTION
It can be useful for external programs to know the list of files a script
depends on. For instance, a program can watch that list of files and run jk
when one of them changes as it's possible running the script will produce a
different output.

We current emit only file dependencies:

  - import-file: a file imported through an import statement
  - parameter-file: a file with script input parameters specified with `-f`
  - read-file: a file read by std lthe output has changed as well.ib

```console
$ jk run -f params.json -d ./read-simple.js 
[
  {
    "kind": "import-file",
    "path": "/home/damien/go/src/github.com/jkcfg/jk/read-simple.js",
    "specifier": "./read-simple.js"
  },
  {
    "kind": "parameter-file",
    "path": "/home/damien/go/src/github.com/jkcfg/jk/params.json"
  },
  {
    "kind": "import-file",
    "path": "/home/damien/go/src/github.com/jkcfg/jk/foo.js",
    "specifier": "./foo"
  },
  {
    "kind": "read-file",
    "path": "/home/damien/go/src/github.com/jkcfg/jk/svc-myapp.yaml"
  }
]
```

Fixes: #172