### PR TITLE
Prep refactoring work for generate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/google/flatbuffers v1.10.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2
+	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720 h1:YBgCfrSk4xZOH//
 github.com/jkcfg/v8worker2 v0.0.0-20190217191700-405919a64720/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2 h1:yroXZIO0q4uBioF+qxfrstz58/0kCKGJsBFd1Vd2OYg=
 github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ry/v8worker2 v0.0.0-20190118154056-6857a7739bc2 h1:nvqxIeI0eVhPV4d3UubaTiadSnAha1DaqMOBN0E3kqg=

--- a/params_option.go
+++ b/params_option.go
@@ -23,11 +23,11 @@ type paramsOption struct {
 	files  *[]string
 }
 
-func parameters(source paramSource) pflag.Value {
+func parameters(opts *vmOptions, source paramSource) pflag.Value {
 	return &paramsOption{
-		params: &runOptions.parameters,
+		params: &opts.parameters,
 		source: source,
-		files:  &runOptions.parameterFiles,
+		files:  &opts.parameterFiles,
 	}
 }
 

--- a/params_option.go
+++ b/params_option.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jkcfg/jk/pkg/std"
+	"github.com/spf13/pflag"
+)
+
+type paramSource int
+
+const (
+	paramSourceFile paramSource = iota
+	paramSourceCommandLine
+)
+
+// paramsOption implements a pflag.Value for script input parameters.
+type paramsOption struct {
+	params *std.Params
+	source paramSource
+	files  *[]string
+}
+
+func parameters(source paramSource) pflag.Value {
+	return &paramsOption{
+		params: &runOptions.parameters,
+		source: source,
+		files:  &runOptions.parameterFiles,
+	}
+}
+
+func (p *paramsOption) String() string {
+	return ""
+}
+
+func (p *paramsOption) setFromFile(s string) error {
+	params, err := std.NewParamsFromFile(s)
+	if err != nil {
+		return fmt.Errorf("%s: %v", s, err)
+	}
+	if p.files != nil {
+		*p.files = append(*p.files, s)
+	}
+
+	p.params.Merge(params)
+
+	return nil
+}
+
+func (p *paramsOption) setFromCommandline(s string) error {
+	parts := strings.Split(s, "=")
+	if len(parts) != 2 {
+		return errors.New("input parameters are of the form name=value")
+	}
+	path := parts[0]
+	v := parts[1]
+
+	p.params.SetString(path, v)
+	return nil
+}
+
+func (p *paramsOption) Set(s string) error {
+	if p.source == paramSourceFile {
+		return p.setFromFile(s)
+	}
+	return p.setFromCommandline(s)
+}
+
+func (p *paramsOption) Type() string {
+	if p.source == paramSourceFile {
+		return "filename"
+	}
+	return "name=value"
+}

--- a/run.go
+++ b/run.go
@@ -123,7 +123,4 @@ func run(cmd *cobra.Command, args []string) {
 	if runErr != nil {
 		log.Fatal(runErr)
 	}
-
-	vm.Wait()
-	vm.Finish()
 }

--- a/run.go
+++ b/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -10,12 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jkcfg/jk/pkg/deferred"
-	"github.com/jkcfg/jk/pkg/record"
-	"github.com/jkcfg/jk/pkg/resolve"
-	"github.com/jkcfg/jk/pkg/std"
-
-	v8 "github.com/jkcfg/v8worker2"
 	"github.com/spf13/cobra"
 )
 
@@ -53,13 +46,6 @@ func examples() string {
 	return b.String()
 }
 
-const errorHandler = `
-function onerror(msg, src, line, col, err) {
-  V8Worker2.print("Promise rejected at", src, line + ":" + col);
-  V8Worker2.print(err.stack);
-}
-`
-
 const inlineTemplate = `
 import { log, write, read } from '@jkcfg/std';
 import { dir, info } from '@jkcfg/std/fs';
@@ -68,42 +54,19 @@ import * as param from '@jkcfg/std/param';
 %s;
 `
 
-const global = `
-var global = {};
-`
-
 var runOptions struct {
+	vmOptions
+
 	// control how the argument is interpreted; by default, it's a
 	// file to load
 	module, inline bool
-
-	verbose          bool
-	outputDirectory  string
-	inputDirectory   string
-	parameters       std.Params
-	parameterFiles   []string // list of files specified on the command line with -f.
-	emitDependencies bool
-
-	debugImports bool
 }
 
 func init() {
-	runOptions.parameters = std.NewParams()
-
 	runCmd.PersistentFlags().BoolVarP(&runOptions.module, "module", "m", false, "treat argument as specifying a module to load")
 	runCmd.PersistentFlags().BoolVarP(&runOptions.inline, "exec", "c", false, "treat argument as specifying literal JavaScript to execute")
 
-	runCmd.PersistentFlags().BoolVarP(&runOptions.verbose, "verbose", "v", false, "verbose output")
-	runCmd.PersistentFlags().StringVarP(&runOptions.outputDirectory, "output-directory", "o", "", "where to output generated files")
-	runCmd.PersistentFlags().StringVarP(&runOptions.inputDirectory, "input-directory", "i", "", "where to find files read in the script; if not set, the directory containing the script is used")
-	runCmd.PersistentFlags().VarP(parameters(paramSourceCommandLine), "parameter", "p", "boolean input parameter")
-	parameterFlag := runCmd.PersistentFlags().VarPF(parameters(paramSourceFile), "parameters", "f", "load parameters from a JSON or YAML file")
-	parameterFlag.Annotations = map[string][]string{
-		cobra.BashCompFilenameExt: {"json", "yaml", "yml"},
-	}
-	runCmd.PersistentFlags().BoolVarP(&runOptions.emitDependencies, "emit-dependencies", "d", false, "emit script dependencies")
-	runCmd.PersistentFlags().BoolVar(&runOptions.debugImports, "debug-imports", false, "trace import logic")
-	runCmd.PersistentFlags().MarkHidden("debug-imports")
+	initVMFlags(runCmd, &runOptions.vmOptions)
 
 	jk.AddCommand(runCmd)
 }
@@ -113,23 +76,6 @@ func runArgs(cmd *cobra.Command, args []string) error {
 		return errors.New("run requires an input script")
 	}
 	return nil
-}
-
-type exec struct {
-	worker     *v8.Worker
-	workingDir string
-	resources  std.ResourceBaser
-	recorder   *record.Recorder
-}
-
-func (e *exec) onMessageReceived(msg []byte) []byte {
-	return std.Execute(msg, e.worker, std.ExecuteOptions{
-		Verbose:         runOptions.verbose,
-		Parameters:      runOptions.parameters,
-		OutputDirectory: runOptions.outputDirectory,
-		Root:            std.ReadBase{Path: e.workingDir, Resources: e.resources, Recorder: e.recorder},
-		DryRun:          runOptions.emitDependencies,
-	})
 }
 
 func run(cmd *cobra.Command, args []string) {
@@ -154,114 +100,30 @@ func run(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	inputDir := scriptDir
-	if runOptions.inputDirectory != "" {
-		inputDir, err = filepath.Abs(runOptions.inputDirectory)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	resources := std.NewModuleResources()
-
-	engine := &exec{workingDir: inputDir, resources: resources}
-
-	if runOptions.emitDependencies {
-		engine.recorder = &record.Recorder{}
-		// Add the parameter files to the list of dependencies.
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Fatal("run: unable to get current working directory:", err)
-		}
-		for _, f := range runOptions.parameterFiles {
-			engine.recorder.Record(record.ParameterFile, record.Params{
-				"path": filepath.Join(cwd, f),
-			})
-		}
-	}
-
-	worker := v8.New(engine.onMessageReceived)
-	engine.worker = worker
-
-	if err := worker.Load("errorHandler", errorHandler); err != nil {
-		log.Fatal(err)
-	}
-	if err := worker.Load("global", global); err != nil {
-		log.Fatal(err)
-	}
-
-	resolve.Debug(runOptions.debugImports)
-	resolver := resolve.NewResolver(worker, scriptDir,
-		&resolve.MagicImporter{Specifier: "@jkcfg/std/resource", Generate: resources.MakeModule},
-		&resolve.StaticImporter{Specifier: "std", Resolved: "@jkcfg/std/index.js", Source: std.Module("index.js")},
-		&resolve.StdImporter{
-			// List here the modules users are allowed to access. We map an external
-			// module name to an internal module name to not link the file name used when
-			// writing the standard library to a module name visible to the user.
-			// eg.:
-			//     import * as param from '@jkcfg/std/param.';
-			// The name exposed to users is 'param.js', the file implementing this module
-			// is 'std_param.js'
-			//    { "param.js", "std_param.js" }
-			PublicModules: []resolve.StdPublicModule{{
-				ExternalName: "index.js", InternalModule: "index.js",
-			}, {
-				ExternalName: "param.js", InternalModule: "param.js",
-			}, {
-				ExternalName: "fs.js", InternalModule: "fs.js",
-			}, {
-				ExternalName: "merge.js", InternalModule: "merge.js",
-			}},
-		},
-		&resolve.FileImporter{},
-		&resolve.NodeImporter{ModuleBase: scriptDir},
-	)
-	resolver.SetRecorder(engine.recorder)
+	vm := newVM(&runOptions.vmOptions)
+	vm.SetWorkingDirectory(scriptDir)
 
 	var runErr error
 
 	switch {
 	case runOptions.module:
-		_, ret := resolver.ResolveModule(args[0], ToplevelReferrer)
-		if ret != 0 {
-			runErr = fmt.Errorf("unable to load module %q", args[0])
-		}
+		runErr = vm.RunModule(args[0], ToplevelReferrer)
 	case runOptions.inline:
-		runErr = worker.LoadModule(InlineSpecifier, fmt.Sprintf(inlineTemplate, args[0]), resolver.ResolveModule)
+		runErr = vm.Run(InlineSpecifier, fmt.Sprintf(inlineTemplate, args[0]))
 	case args[0] == "-":
 		input, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			log.Fatal(err)
 		}
-		runErr = worker.LoadModule(StdinSpecifier, string(input), resolver.ResolveModule)
+		runErr = vm.Run(StdinSpecifier, string(input))
 	default: // a file
-		// Add the script to the list of dependencies.
-		filename := args[0]
-		if engine.recorder != nil {
-			abspath, _ := filepath.Abs(filename)
-			engine.recorder.Record(record.ImportFile, record.Params{
-				"specifier": filename,
-				"path":      abspath,
-			})
-		}
-		input, err := ioutil.ReadFile(filename)
-		if err != nil {
-			log.Fatal(err)
-		}
-		runErr = worker.LoadModule(filepath.Base(filename), string(input), resolver.ResolveModule)
+		runErr = vm.RunFile(args[0])
 	}
 
 	if runErr != nil {
 		log.Fatal(runErr)
 	}
 
-	deferred.Wait() // TODO(michael): hide this in std?
-
-	if engine.recorder != nil {
-		data, err := json.MarshalIndent(engine.recorder, "", "  ")
-		if err != nil {
-			log.Fatal("emit-dependencies:", err)
-		}
-		fmt.Println(string(data))
-	}
+	vm.Wait()
+	vm.Finish()
 }

--- a/run.go
+++ b/run.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/jkcfg/jk/pkg/deferred"
 	"github.com/jkcfg/jk/pkg/record"
@@ -18,7 +17,6 @@ import (
 
 	v8 "github.com/jkcfg/v8worker2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var runCmd = &cobra.Command{
@@ -29,8 +27,6 @@ var runCmd = &cobra.Command{
 	Run:     run,
 }
 
-type paramSource int
-
 // InlineSpecifier is used as the initial module specifier when exec'ing literal JavaScript
 const InlineSpecifier = "<exec>"
 
@@ -39,11 +35,6 @@ const StdinSpecifier = "<stdin>"
 
 // ToplevelReferrer is used as the module referrer when using --module
 const ToplevelReferrer = "<toplevel>"
-
-const (
-	paramSourceFile paramSource = iota
-	paramSourceCommandLine
-)
 
 func examples() string {
 	b := bytes.Buffer{}
@@ -81,56 +72,6 @@ const global = `
 var global = {};
 `
 
-type paramsOption struct {
-	params *std.Params
-	source paramSource
-	files  *[]string
-}
-
-func (p *paramsOption) String() string {
-	return ""
-}
-
-func (p *paramsOption) setFromFile(s string) error {
-	params, err := std.NewParamsFromFile(s)
-	if err != nil {
-		return fmt.Errorf("%s: %v", s, err)
-	}
-	if p.files != nil {
-		*p.files = append(*p.files, s)
-	}
-
-	p.params.Merge(params)
-
-	return nil
-}
-
-func (p *paramsOption) setFromCommandline(s string) error {
-	parts := strings.Split(s, "=")
-	if len(parts) != 2 {
-		return errors.New("input parameters are of the form name=value")
-	}
-	path := parts[0]
-	v := parts[1]
-
-	p.params.SetString(path, v)
-	return nil
-}
-
-func (p *paramsOption) Set(s string) error {
-	if p.source == paramSourceFile {
-		return p.setFromFile(s)
-	}
-	return p.setFromCommandline(s)
-}
-
-func (p *paramsOption) Type() string {
-	if p.source == paramSourceFile {
-		return "filename"
-	}
-	return "name=value"
-}
-
 var runOptions struct {
 	// control how the argument is interpreted; by default, it's a
 	// file to load
@@ -144,14 +85,6 @@ var runOptions struct {
 	emitDependencies bool
 
 	debugImports bool
-}
-
-func parameters(source paramSource) pflag.Value {
-	return &paramsOption{
-		params: &runOptions.parameters,
-		source: source,
-		files:  &runOptions.parameterFiles,
-	}
 }
 
 func init() {

--- a/vm.go
+++ b/vm.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/jkcfg/jk/pkg/deferred"
+	"github.com/jkcfg/jk/pkg/record"
+	"github.com/jkcfg/jk/pkg/resolve"
+	"github.com/jkcfg/jk/pkg/std"
+	v8 "github.com/jkcfg/v8worker2"
+	"github.com/spf13/cobra"
+)
+
+type vmOptions struct {
+	verbose          bool
+	outputDirectory  string
+	inputDirectory   string
+	parameters       std.Params
+	parameterFiles   []string // list of files specified on the command line with -f.
+	emitDependencies bool
+
+	debugImports bool
+}
+
+func initVMFlags(cmd *cobra.Command, opts *vmOptions) {
+	opts.parameters = std.NewParams()
+
+	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
+	cmd.PersistentFlags().StringVarP(&opts.outputDirectory, "output-directory", "o", "", "where to output generated files")
+	cmd.PersistentFlags().StringVarP(&opts.inputDirectory, "input-directory", "i", "", "where to find files read in the script; if not set, the directory containing the script is used")
+	cmd.PersistentFlags().VarP(parameters(opts, paramSourceCommandLine), "parameter", "p", "boolean input parameter")
+	parameterFlag := cmd.PersistentFlags().VarPF(parameters(opts, paramSourceFile), "parameters", "f", "load parameters from a JSON or YAML file")
+	parameterFlag.Annotations = map[string][]string{
+		cobra.BashCompFilenameExt: {"json", "yaml", "yml"},
+	}
+	cmd.PersistentFlags().BoolVarP(&opts.emitDependencies, "emit-dependencies", "d", false, "emit script dependencies")
+	cmd.PersistentFlags().BoolVar(&opts.debugImports, "debug-imports", false, "trace import logic")
+	cmd.PersistentFlags().MarkHidden("debug-imports")
+}
+
+const errorHandler = `
+function onerror(msg, src, line, col, err) {
+  V8Worker2.print("Promise rejected at", src, line + ":" + col);
+  V8Worker2.print(err.stack);
+}
+`
+
+const global = `
+var global = {};
+`
+
+type vm struct {
+	vmOptions
+
+	scriptDir string
+	inputDir  string
+
+	worker    *v8.Worker
+	recorder  *record.Recorder
+	resources *std.ModuleResources
+}
+
+func (vm *vm) onMessageReceived(msg []byte) []byte {
+	return std.Execute(msg, vm.worker, std.ExecuteOptions{
+		Verbose:         vm.verbose,
+		Parameters:      vm.parameters,
+		OutputDirectory: vm.outputDirectory,
+		Root:            std.ReadBase{Path: vm.inputDir, Resources: vm.resources, Recorder: vm.recorder},
+		DryRun:          vm.emitDependencies,
+	})
+}
+
+func newVM(opts *vmOptions) *vm {
+	vm := &vm{
+		vmOptions: *opts,
+		resources: std.NewModuleResources(),
+	}
+
+	if opts.emitDependencies {
+		recorder := &record.Recorder{}
+		// Add the parameter files to the list of dependencies.
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal("run: unable to get current working directory:", err)
+		}
+		for _, f := range opts.parameterFiles {
+			recorder.Record(record.ParameterFile, record.Params{
+				"path": filepath.Join(cwd, f),
+			})
+		}
+		vm.recorder = recorder
+	}
+
+	worker := v8.New(vm.onMessageReceived)
+	if err := worker.Load("errorHandler", errorHandler); err != nil {
+		log.Fatal(err)
+	}
+	if err := worker.Load("global", global); err != nil {
+		log.Fatal(err)
+	}
+	vm.worker = worker
+
+	resolve.Debug(opts.debugImports)
+
+	return vm
+}
+
+func (vm *vm) SetWorkingDirectory(dir string) {
+	vm.scriptDir = dir
+
+	inputDir := dir
+	if vm.inputDirectory != "" {
+		var err error
+		inputDir, err = filepath.Abs(vm.inputDirectory)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	vm.inputDir = inputDir
+}
+
+func (vm *vm) resolver() *resolve.Resolver {
+	// TODO(damien): there's an ugly dependency here. The user of the vm object has
+	// to call SetWorkingDir before being able to call Run* functions.
+	resolver := resolve.NewResolver(vm.worker, vm.scriptDir,
+		&resolve.MagicImporter{Specifier: "@jkcfg/std/resource", Generate: vm.resources.MakeModule},
+		&resolve.StaticImporter{Specifier: "std", Resolved: "@jkcfg/std/index.js", Source: std.Module("index.js")},
+		&resolve.StdImporter{
+			// List here the modules users are allowed to access. We map an external
+			// module name to an internal module name to not link the file name used when
+			// writing the standard library to a module name visible to the user.
+			// eg.:
+			//     import * as param from '@jkcfg/std/param.';
+			// The name exposed to users is 'param.js', the file implementing this module
+			// is 'std_param.js'
+			//    { "param.js", "std_param.js" }
+			PublicModules: []resolve.StdPublicModule{{
+				ExternalName: "index.js", InternalModule: "index.js",
+			}, {
+				ExternalName: "param.js", InternalModule: "param.js",
+			}, {
+				ExternalName: "fs.js", InternalModule: "fs.js",
+			}, {
+				ExternalName: "merge.js", InternalModule: "merge.js",
+			}},
+		},
+		&resolve.FileImporter{},
+		&resolve.NodeImporter{ModuleBase: vm.scriptDir},
+	)
+	resolver.SetRecorder(vm.recorder)
+	return resolver
+}
+
+func (vm *vm) Run(specifier string, source string) error {
+	resolver := vm.resolver()
+	return vm.worker.LoadModule(specifier, source, resolver.ResolveModule)
+}
+
+func (vm *vm) RunModule(specifier string, referrer string) error {
+	resolver := vm.resolver()
+	_, ret := resolver.ResolveModule(specifier, referrer)
+	if ret != 0 {
+		return fmt.Errorf("unable to load module %q", specifier)
+	}
+	return nil
+}
+
+func (vm *vm) RunFile(filename string) error {
+	// Add the script to the list of dependencies.
+	if vm.recorder != nil {
+		abspath, _ := filepath.Abs(filename)
+		vm.recorder.Record(record.ImportFile, record.Params{
+			"specifier": filename,
+			"path":      abspath,
+		})
+	}
+	input, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resolver := vm.resolver()
+	return vm.worker.LoadModule(filepath.Base(filename), string(input), resolver.ResolveModule)
+}
+
+func (vm *vm) Wait() {
+	deferred.Wait() // TODO(michael): hide this in std?
+}
+
+func (vm *vm) Finish() {
+	if vm.recorder != nil {
+		data, err := json.MarshalIndent(vm.recorder, "", "  ")
+		if err != nil {
+			log.Fatal("emit-dependencies:", err)
+		}
+		fmt.Println(string(data))
+	}
+}


### PR DESCRIPTION
This PR refactors run into a `vm` object that can be reused to implement the generate command. I thought better submit this quickly than let it bitrot locally.