### PR TITLE
generate: Support default export being a function

### DIFF
--- a/std/generate.js
+++ b/std/generate.js
@@ -170,7 +170,18 @@ function validate(value, params) {
 }
 
 
-function generate(definition, params) {
+function generate(defaultExport, params) {
+  /*
+   * The default export can be:
+   *  1. an array of { file, value } objects,
+   *  2. a promise to such an array,
+   *  3. a function evaluating to either 1. or 2.
+   */
+  let definition = defaultExport;
+  if (typeof definition === 'function') {
+    definition = definition();
+  }
+
   Promise.resolve(definition).then((files) => {
     const { valid, stdoutFormat, showHelp } = validate(files, params);
     if (showHelp) {

--- a/tests/generate-function.js
+++ b/tests/generate-function.js
@@ -1,0 +1,5 @@
+export default function f(message = 'success') {
+  return [
+    { file: 'object.yaml', value: { message } },
+  ];
+}

--- a/tests/test-generate-function.expected/object.yaml
+++ b/tests/test-generate-function.expected/object.yaml
@@ -1,0 +1,1 @@
+message: success

--- a/tests/test-generate-function.js.cmd
+++ b/tests/test-generate-function.js.cmd
@@ -1,0 +1,1 @@
+jk generate -o %d %t.js


### PR DESCRIPTION
The desire for the default export being a function has emerged from a comment
in:

   https://github.com/jkcfg/jk/issues/125#issuecomment-491935449

That makes sense and is fortunately easy to add!