### PR TITLE
build: Don't tell github we're the std package

### DIFF
--- a/std/package-lock.json
+++ b/std/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "std",
+  "name": "@jkcfg/std",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/tests/test-std-ts/package.json
+++ b/tests/test-std-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "test-std-ts",
   "version": "0.1.0",
   "description": "test case",
   "scripts": {


### PR DESCRIPTION
Github believe we are the std package because the lock files still mentions
'std'. This means github things we are used by 3,059 packages. That's nice but
far from the truth.