### PR TITLE
Wire through the maintainer as a label on Kubernetes objects

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ The examples directory contains various examples illustrating how one can use
 ## jk
 
 - [Your first `jk` program](quick-start/alice)
-- [Generate a simple terraform file](quick-start/terraform-github)
+- [A simple terraform file](quick-start/terraform-github)
 
 ## Docker
 

--- a/examples/kubernetes/micro-service/kubernetes.js
+++ b/examples/kubernetes/micro-service/kubernetes.js
@@ -10,6 +10,7 @@ function Deployment(service) {
       namespace: service.namespace,
       labels: {
         app: service.name,
+        maintainer: service.maintainer,
       },
     },
     spec: {
@@ -25,6 +26,7 @@ function Deployment(service) {
         metadata: {
           labels: {
             app: service.name,
+            maintainer: service.maintainer,
           },
         },
         spec: {
@@ -47,6 +49,7 @@ function Service(service) {
       namespace: service.namespace,
       labels: {
         app: service.name,
+        maintainer: service.maintainer,
       },
     },
     spec: {
@@ -66,6 +69,7 @@ function Ingress(service) {
       namespace: service.namespace,
       labels: {
         app: service.name,
+        maintainer: service.maintainer,
       },
       annotations: {
         'nginx.ingress.kubernetes.io/rewrite-target': '/',

--- a/examples/kubernetes/micro-service/kubernetes.js
+++ b/examples/kubernetes/micro-service/kubernetes.js
@@ -64,6 +64,9 @@ function Ingress(service) {
   return new api.extensions.v1beta1.Ingress(service.name, {
     metadata: {
       namespace: service.namespace,
+      labels: {
+        app: service.name,
+      },
       annotations: {
         'nginx.ingress.kubernetes.io/rewrite-target': '/',
       },


### PR DESCRIPTION
We have defined a maintainer on the micro-service object, might as well wire it up to the resulting Kubernetes objects.