### PR TITLE
examples: Add a selector to Kubernetes Deployments

### DIFF
--- a/examples/kubernetes/micro-service/kubernetes.js
+++ b/examples/kubernetes/micro-service/kubernetes.js
@@ -14,6 +14,11 @@ function Deployment(service) {
       },
     },
     spec: {
+      selector: {
+        matchLabels: {
+          app: service.name,
+        },
+      },
       replicas: service.replicas,
       revisionHistoryLimit: 2,
       strategy: {


### PR DESCRIPTION
Oops, the TypeScript validation did catch something good! we didn't specify a selector in an `apps/v1` Deployment!