### PR TITLE
examples: Fix the latency graph legend

### DIFF
--- a/examples/kubernetes/micro-service/dashboard.js
+++ b/examples/kubernetes/micro-service/dashboard.js
@@ -33,8 +33,8 @@ const RPSHttp = service => new G.Dashboard(`Service > ${service.name}`)
       ],
     })
       .addTargets([
-        new G.Prometheus(ServiceLatency(selector(service))[0], { legendFormat: '{{route}} 99th percentile' }),
-        new G.Prometheus(ServiceLatency(selector(service))[1], { legendFormat: '{{route}} median' }),
+        new G.Prometheus(ServiceLatency(selector(service))[0], { legendFormat: '99th percentile' }),
+        new G.Prometheus(ServiceLatency(selector(service))[1], { legendFormat: 'median' }),
         new G.Prometheus(ServiceLatency(selector(service))[2], { legendFormat: 'mean' }),
       ]),
     {


### PR DESCRIPTION
This particular panel is the average of all routes, not a per-route latency
graph.