### PR TITLE
std: Fix logging undefined values

### DIFF
--- a/std/log.ts
+++ b/std/log.ts
@@ -1,6 +1,10 @@
 import { write, WriteOptions } from './write';
 
 function log(value: any, options?: WriteOptions): void {
+  if (value === undefined) {
+    V8Worker2.print('undefined');
+    return;
+  }
   write(value, '', options);
 }
 

--- a/std/write.ts
+++ b/std/write.ts
@@ -10,6 +10,10 @@ interface WriteOptions {
 }
 
 function write(value: any, path = '', { format = Format.FromExtension, indent = 2, overwrite = true }: WriteOptions = {}): void {
+  if (value === undefined) {
+    throw TypeError('cannot write undefined value');
+  }
+
   const builder = new flatbuffers.Builder(1024);
   const str = (format === Format.Raw) ? value.toString() : JSON.stringify(value);
   const strOff = builder.createString(str);

--- a/tests/test-log.js
+++ b/tests/test-log.js
@@ -3,7 +3,7 @@ import std from '@jkcfg/std';
 // We can print basic types to stdout.
 std.log(1.2);
 std.log('foo');
-// XXX std.log(undefined);
+std.log(undefined);
 std.log(null);
 
 // We can print an object to stdout.

--- a/tests/test-log.js.expected
+++ b/tests/test-log.js.expected
@@ -1,5 +1,6 @@
 1.2
 foo
+undefined
 null
 {
   "foo": 1.2,


### PR DESCRIPTION
Instead of having log(undefined) throw a weird looking exception, we should
just print 'undefined'!

I've also changed write() to throw a human readable error when attempting to
write an undefined value. I don't think we want to silently ignore this, might
as well tell the user something is odd.

Fixes: 221