### PR TITLE
Makefile: make the build static to ease running in lean docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       services:
         - docker
       script:
-        - ./run-in-docker.sh make dep install test api-reference
+        - ./run-in-docker.sh make dep install test api-reference STATIC=yes
 
     - os: osx
       osx_image: xcode10.1

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: jk
 VERSION := $(shell git describe --tags)
 
 jk: pkg/__std/lib/assets_vfsdata.go FORCE
-	GO111MODULE=on go build -o $@ -ldflags "-X main.Version=$(VERSION)"
+	GO111MODULE=on go build -a -tags netgo -o $@ -ldflags '-X main.Version=$(VERSION) -extldflags "-static"'
 
 pkg/__std/lib/assets_vfsdata.go: std/internal/__std_generated.ts std/dist/index.js
 	GO111MODULE=on go generate ./pkg/__std/lib

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ all: jk
 VERSION := $(shell git describe --tags)
 
 jk: pkg/__std/lib/assets_vfsdata.go FORCE
+ifeq ($(STATIC),yes)
 	GO111MODULE=on go build -a -tags netgo -o $@ -ldflags '-X main.Version=$(VERSION) -extldflags "-static"'
+else
+	GO111MODULE=on go build -o $@ -ldflags "-X main.Version=$(VERSION)"
+endif
 
 pkg/__std/lib/assets_vfsdata.go: std/internal/__std_generated.ts std/dist/index.js
 	GO111MODULE=on go generate ./pkg/__std/lib


### PR DESCRIPTION
Docker images such as `busybox` lack the runtime libraries that are required by the current build of jk. This PR is to mitigate that problem by linking jk statically. There is no significant binary size impact.

I've tested the Linux amd64 build. I haven't tested the Darwin one.