### PR TITLE
std: Introduce a mergeFull function

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -2,6 +2,16 @@
 
 ## Deprecated in 0.2.x (will be removed in 0.3.0)
 
+### merge and patch std functions
+
+*Deprecated in 0.2.10*
+
+The `merge` and `patch` function of the `@jkcfg/std/merge` module have been
+deprecated in favour of the more general `mergeFull` function.
+
+- `merge` and `patch` will be removed in `0.3.0`.
+- `mergeFull` will be renamed to `merge` in `0.3.0`.
+
 ### std import
 
 *Deprecated in 0.2.5*

--- a/std/.eslintrc
+++ b/std/.eslintrc
@@ -24,6 +24,7 @@
     "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
     "no-use-before-define": ["error", { "functions": false }],
     "no-shadow": 0,
-    "no-param-reassign": 0
+    "no-param-reassign": 0,
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   }
 }

--- a/std/merge.js
+++ b/std/merge.js
@@ -87,8 +87,12 @@ function mergeFunc(rule, key, defaultFunc) {
     return defaultFunc;
   }
 
-  if (typeof f !== 'function') {
-    throw new Error(`merge: expected a function in the rules objects but found a ${typeof f}`);
+  const t = typeof f;
+  if (t === 'object' && t !== 'function') {
+    return deep(f);
+  }
+  if (t !== 'function') {
+    throw new Error(`merge: expected a function in the rules objects but found a ${t}`);
   }
 
   return f;
@@ -170,9 +174,9 @@ function arrayMergeWithKey(a, b, mergeKey, rules) {
  * };
  *
  * mergeFull(pod, sidecarImage, {
- *   spec: deep({
+ *   spec: {
  *     containers: deepWithKey('name'),
- *   }),
+ *   },
  * });
  * ```
  *

--- a/std/merge.js
+++ b/std/merge.js
@@ -121,6 +121,47 @@ export function deep(rules) {
   return (a, b) => objectMerge2(a, b, rules);
 }
 
+/**
+ * Merge strategy merging two values by selecting the second value.
+ *
+ * **Example**:
+ *
+ * ```js
+ * let a = {
+ *   k0: 1,
+ *   o: {
+ *     o0: 'a string',
+ *     o1: 'this will go away!',
+ *   },
+ * };
+ *
+ * let b = {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   },
+ * };
+ *
+ * mergeFull(a, b, { o: replace() });
+ * ```
+ *
+ * Will give the result:
+ *
+ * ```js
+ * {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   },
+ * }
+ * ```
+ */
+export function replace() {
+  return (_, b) => b;
+}
+
 function arrayMergeWithKey(a, b, mergeKey, rules) {
   const r = Array.from(a);
   const toAppend = [];

--- a/std/merge.js
+++ b/std/merge.js
@@ -81,6 +81,247 @@ function objectMerge(obj, mergeObj) {
   return r;
 }
 
+function mergeFunc(rule, key, defaultFunc) {
+  if (rule === undefined) {
+    return defaultFunc;
+  }
+
+  const f = rule[key];
+  if (f === undefined) {
+    return defaultFunc;
+  }
+
+  if (typeof f !== 'function') {
+    throw new Error(`merge: expected a function in the rules objects but found a ${typeof f}`);
+  }
+
+  return f;
+}
+
+function objectMerge2(a, b, rules) {
+  const r = {};
+
+  Object.assign(r, a);
+  for (const [key, value] of Object.entries(b)) {
+    r[key] = mergeFunc(rules, key, mergeFull)(a[key], value);
+  }
+  return r;
+}
+
+/**
+ * Merge strategy deep merging objects.
+ *
+ * @param rules optional set of merging rules.
+ *
+ * `deep` will deep merge objects. This is the default merging strategy of
+ * objects. It's possible to provide a set of rules to override the merge
+ * strategy for some properties. See [[mergeFull]].
+ */
+export function deep(rules) {
+  return (a, b) => objectMerge2(a, b, rules);
+}
+
+function arrayMergeWithKey(a, b, mergeKey, rules) {
+  const r = Array.from(a);
+  const toAppend = [];
+
+  for (const value of b) {
+    const i = a.findIndex(o => o[mergeKey] === value[mergeKey]);
+    if (i === -1) {
+      // Object doesn't exist in a, save it in the list of objects to append.
+      toAppend.push(value);
+      continue;
+    }
+    r[i] = objectMerge2(a[i], value, rules);
+  }
+
+  Array.prototype.push.apply(r, toAppend);
+  return r;
+}
+
+/**
+ * Merge strategy for arrays of objects, deep merging objects having the same
+ * `mergeKey`.
+ *
+ * @param mergeKey key used to identify the same object.
+ * @param rules optional set of rules to merge each object.
+ *
+ * **Example**:
+ *
+ * ```js
+ * import { mergeFull, deep, deepWithKey } from '@jkcfg/std/merge';
+ *
+ * const pod = {
+ *   spec: {
+ *     containers: [{
+ *       name: 'my-app',
+ *       image: 'busybox',
+ *       command: ['sh', '-c', 'echo Hello Kubernetes!'],
+ *     },{
+ *       name: 'sidecar',
+ *       image: 'sidecar:v1',
+ *     }],
+ *   },
+ * };
+ *
+ * const sidecarImage = {
+ *   spec: {
+ *     containers: [{
+ *       name: 'sidecar',
+ *       image: 'sidecar:v2',
+ *     }],
+ *   },
+ * };
+ *
+ * mergeFull(pod, sidecarImage, {
+ *   spec: deep({
+ *     containers: deepWithKey('name'),
+ *   }),
+ * });
+ * ```
+ *
+ * Will result to:
+ *
+ * ```js
+ * {
+ *   spec: {
+ *     containers: [
+ *       {
+ *         command: [
+ *           'sh',
+ *           '-c',
+ *           'echo Hello Kubernetes!',
+ *         ],
+ *         image: 'busybox',
+ *         name: 'my-app',
+ *       },
+ *       {
+ *         image: 'sidecar:v2',
+ *         name: 'sidecar',
+ *       },
+ *     ],
+ *   },
+ * }
+ * ```
+ */
+export function deepWithKey(mergeKey, rules) {
+  return (a, b) => arrayMergeWithKey(a, b, mergeKey, rules);
+}
+
+/**
+ * Merges `b` into `a` with optional merging rule(s).
+ *
+ * @param a Base value.
+ * @param b Merge value.
+ * @param rule Set of merge rules.
+ *
+ * `mergeFull` will recursively merge two values `a` and `b`. By default:
+ *
+ * - if `a` and `b` are primitive types, `b` is the result of the merge.
+ * - if `a` and `b` are arrays, `b` is the result of the merge.
+ * - if `a` and `b` are objects, every own property is merged with this very
+ * set of default rules.
+ * - the process is recursive, effectively deep merging objects.
+ *
+ * if `a` and `b` have different types, `mergeFull` will throw an error.
+ *
+ * **Examples**:
+ *
+ * Merge primitive values with the default rules:
+ *
+ * ```js
+ * mergeFull(1, 2);
+ *
+ * > 2
+ * ```
+ *
+ * Merge objects with the default rules:
+ *
+ * ```js
+ * const a = {
+ *   k0: 1,
+ *   o: {
+ *     o0: 'a string',
+ *   },
+ * };
+ *
+ * let b = {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   },
+ * }
+ *
+ * mergeFull(a, b);
+ *
+ * >
+ * {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   }
+ * }
+ * ```
+ *
+ * **Merge strategies**
+ *
+ * It's possible to override the default merging rules by specifying a merge
+ * strategy, a function that will compute the result of the merge.
+ *
+ * For primitive values and arrays, the third argument of `mergeFull` is a
+ * function:
+ *
+ * ```js
+ * const add = (a, b) => a + b;
+ * mergeFull(1, 2, add);
+ *
+ * > 3
+ * ```
+ *
+ * For objects, each own property can be merged with different strategies. The
+ * third argument of `mergeFull` is an object associating properties with merge
+ * functions.
+ *
+ *
+ * ```js
+ * // merge a and b, adding the values of the `k0` property.
+ * mergeFull(a, b, { k0: add });
+ *
+ * >
+ * {
+ *   k0: 3,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   }
+ * }
+ * ```
+ */
+export function mergeFull(a, b, rule) {
+  const [typeA, typeB] = [typeof a, typeof b];
+
+  if (a === undefined) {
+    return b;
+  }
+
+  if (typeA !== typeB) {
+    throw new Error(`merge cannot combine values of types ${typeA} and ${typeB}`);
+  }
+
+  // Primitive types and arrays default to being replaced.
+  if (Array.isArray(a) || typeA !== 'object') {
+    if (typeof rule === 'function') {
+      return rule(a, b);
+    }
+    return b;
+  }
+
+  // Objects.
+  return objectMerge2(a, b, rule);
+}
+
 // Interpret a series of transformations expressed either as object
 // patches (as in the argument to `patch` in this module), or
 // functions. Usually the first argument will be an object,

--- a/std/merge.js
+++ b/std/merge.js
@@ -82,11 +82,7 @@ function objectMerge(obj, mergeObj) {
 }
 
 function mergeFunc(rule, key, defaultFunc) {
-  if (rule === undefined) {
-    return defaultFunc;
-  }
-
-  const f = rule[key];
+  const f = rule && rule[key];
   if (f === undefined) {
     return defaultFunc;
   }

--- a/std/merge.js
+++ b/std/merge.js
@@ -180,7 +180,7 @@ function arrayMergeWithKey(a, b, mergeKey, rules) {
  * });
  * ```
  *
- * Will result to:
+ * Will give the result:
  *
  * ```js
  * {

--- a/std/merge.js
+++ b/std/merge.js
@@ -122,6 +122,46 @@ export function deep(rules) {
 }
 
 /**
+ * Merge strategy merging two values by selecting the first value.
+ *
+ * **Example**:
+ *
+ * ```js
+ * let a = {
+ *   k0: 1,
+ *   o: {
+ *     o0: 'a string',
+ *   },
+ * };
+ *
+ * let b = {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'another string',
+ *   },
+ * };
+ *
+ * mergeFull(a, b, { o: first() });
+ * ```
+ *
+ * Will give the result:
+ *
+ * ```js
+ * {
+ *   k0: 2,
+ *   k1: true,
+ *   o: {
+ *     o0: 'a string',
+ *   },
+ * }
+ * ```
+ */
+export function first() {
+  return (a, _) => a;
+}
+
+/**
  * Merge strategy merging two values by selecting the second value.
  *
  * **Example**:

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -1,4 +1,6 @@
-import { mix, patch, merge } from './merge';
+import {
+  mix, patch, merge, mergeFull, deep, deepWithKey,
+} from './merge';
 
 test('mix objects', () => {
   const r = mix({ foo: 1 }, { bar: 2 }, { foo: 3 });
@@ -143,4 +145,46 @@ test('array patch', () => {
     foo: { bar: 1, ary: ['foo'] },
     baz: 2,
   });
+});
+
+test('mergeFull: default merging of primitive values', () => {
+  expect(mergeFull(1, 2)).toEqual(2);
+  expect(mergeFull('a', 'b')).toEqual('b');
+  expect(() => mergeFull('a', 1)).toThrow();
+  expect(() => mergeFull(true, 'b')).toThrow();
+  expect(mergeFull([1, 2], [3, 4])).toEqual([3, 4]);
+  expect(mergeFull({ foo: 1 }, { bar: 2 })).toEqual({ foo: 1, bar: 2 });
+});
+
+const pod = {
+  spec: {
+    containers: [{
+      name: 'my-app',
+      image: 'busybox',
+      command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600'],
+    }, {
+      name: 'sidecar',
+      image: 'sidecar:v1',
+    }],
+  },
+};
+
+test('mergeFull: array of objects, merging objects identified by a key', () => {
+  const sidecarImage = {
+    spec: {
+      containers: [{
+        name: 'sidecar',
+        image: 'sidecar:v2',
+      }],
+    },
+  };
+
+  const result = mergeFull(pod, sidecarImage, {
+    spec: deep({
+      containers: deepWithKey('name'),
+    }),
+  });
+
+  expect(result.spec.containers.length).toEqual(2);
+  expect(result.spec.containers[1].image).toEqual('sidecar:v2');
 });

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -169,16 +169,16 @@ const pod = {
   },
 };
 
-test('mergeFull: array of objects, merging objects identified by a key', () => {
-  const sidecarImage = {
-    spec: {
-      containers: [{
-        name: 'sidecar',
-        image: 'sidecar:v2',
-      }],
-    },
-  };
+const sidecarImage = {
+  spec: {
+    containers: [{
+      name: 'sidecar',
+      image: 'sidecar:v2',
+    }],
+  },
+};
 
+test('mergeFull: array of objects, merging objects identified by a key', () => {
   const result = mergeFull(pod, sidecarImage, {
     spec: deep({
       containers: deepWithKey('name'),
@@ -190,15 +190,6 @@ test('mergeFull: array of objects, merging objects identified by a key', () => {
 });
 
 test('mergeFull: pick the deep merge strategy when encountering an object as rule', () => {
-  const sidecarImage = {
-    spec: {
-      containers: [{
-        name: 'sidecar',
-        image: 'sidecar:v2',
-      }],
-    },
-  };
-
   const result = mergeFull(pod, sidecarImage, {
     spec: {
       containers: deepWithKey('name'),

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -1,5 +1,5 @@
 import {
-  mix, patch, merge, mergeFull, deep, deepWithKey,
+  mix, patch, merge, mergeFull, deep, replace, deepWithKey,
 } from './merge';
 
 test('mix objects', () => {
@@ -198,4 +198,15 @@ test('mergeFull: pick the deep merge strategy when encountering an object as rul
 
   expect(result.spec.containers.length).toEqual(2);
   expect(result.spec.containers[1].image).toEqual('sidecar:v2');
+});
+
+test('replace: basic', () => {
+  const result = mergeFull(pod, sidecarImage, {
+    spec: {
+      containers: replace(),
+    },
+  });
+
+  expect(result.spec.containers.length).toEqual(1);
+  expect(result.spec.containers[0].name).toEqual('sidecar');
 });

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -1,5 +1,5 @@
 import {
-  mix, patch, merge, mergeFull, deep, replace, deepWithKey,
+  mix, patch, merge, mergeFull, deep, first, replace, deepWithKey,
 } from './merge';
 
 test('mix objects', () => {
@@ -198,6 +198,18 @@ test('mergeFull: pick the deep merge strategy when encountering an object as rul
 
   expect(result.spec.containers.length).toEqual(2);
   expect(result.spec.containers[1].image).toEqual('sidecar:v2');
+});
+
+test('first: basic', () => {
+  const result = mergeFull(pod, sidecarImage, {
+    spec: {
+      containers: first(),
+    },
+  });
+
+  expect(result.spec.containers.length).toEqual(2);
+  expect(result.spec.containers[0].name).toEqual('my-app');
+  expect(result.spec.containers[1].image).toEqual('sidecar:v1');
 });
 
 test('replace: basic', () => {

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -188,3 +188,23 @@ test('mergeFull: array of objects, merging objects identified by a key', () => {
   expect(result.spec.containers.length).toEqual(2);
   expect(result.spec.containers[1].image).toEqual('sidecar:v2');
 });
+
+test('mergeFull: pick the deep merge strategy when encountering an object as rule', () => {
+  const sidecarImage = {
+    spec: {
+      containers: [{
+        name: 'sidecar',
+        image: 'sidecar:v2',
+      }],
+    },
+  };
+
+  const result = mergeFull(pod, sidecarImage, {
+    spec: {
+      containers: deepWithKey('name'),
+    },
+  });
+
+  expect(result.spec.containers.length).toEqual(2);
+  expect(result.spec.containers[1].image).toEqual('sidecar:v2');
+});


### PR DESCRIPTION
We've discussed with @squaremo how we could improve the current state of `std/merge`. `mergeFull` is the result of this.

We can now merge objects and specify for each key a merge strategy, allowing us to implement complex merges and the mechanism to implement Kubernetes strategic merging.

The API doc embed with `mergeFull`, `deep` and `deepWithKey` is somewhat extensive and has details and examples.

**Notes/questions**:

- I'd like to replace both `merge` and `patch` by `mergeFull` in `0.3.0` (renaming it `merge`).
- Should the various strategies live in a separate module?
- Merge strategies are sometimes bound to specify types (ie `deepWithKey` only works with arrays`) but it's not easy to guess that without the API doc (maybe that's fine?)

**TODO**:

- [x] Treat the rule `spec: { containers: deepWithKey('name') }`, as `spec: deep({ containers: deepWithKey('name') })`
- [x] Add deprecation note in the docs

Fixes: #128
Fixes: #231 