### PR TITLE
merge: Assert on the merging strategy input types

### DIFF
--- a/std/merge.js
+++ b/std/merge.js
@@ -108,6 +108,27 @@ function objectMerge2(a, b, rules) {
   return r;
 }
 
+function isObject(o) {
+  const t = typeof o;
+  return t === 'object' && !Array.isArray(o) && !!o;
+}
+
+function assertObject(o, prefix) {
+  if (!isObject(o)) {
+    throw new Error(`${prefix}: input value is not an object`);
+  }
+}
+
+function isArray(a) {
+  return Array.isArray(a);
+}
+
+function assertArray(o, prefix) {
+  if (!isArray(o)) {
+    throw new Error(`${prefix}: input is not an array`);
+  }
+}
+
 /**
  * Merge strategy deep merging objects.
  *
@@ -118,7 +139,11 @@ function objectMerge2(a, b, rules) {
  * strategy for some properties. See [[mergeFull]].
  */
 export function deep(rules) {
-  return (a, b) => objectMerge2(a, b, rules);
+  return (a, b) => {
+    assertObject(a, 'deep');
+    assertObject(b, 'deep');
+    return objectMerge2(a, b, rules);
+  };
 }
 
 /**
@@ -286,7 +311,11 @@ function arrayMergeWithKey(a, b, mergeKey, rules) {
  * ```
  */
 export function deepWithKey(mergeKey, rules) {
-  return (a, b) => arrayMergeWithKey(a, b, mergeKey, rules);
+  return (a, b) => {
+    assertArray(a, 'deepWithKey');
+    assertArray(b, 'deepWithKey');
+    return arrayMergeWithKey(a, b, mergeKey, rules);
+  };
 }
 
 /**

--- a/std/merge.test.js
+++ b/std/merge.test.js
@@ -200,6 +200,44 @@ test('mergeFull: pick the deep merge strategy when encountering an object as rul
   expect(result.spec.containers[1].image).toEqual('sidecar:v2');
 });
 
+test('deep: throw on wrong input type', () => {
+  const sidecarImageNotObject = {
+    spec: [{
+      containers: [{
+        name: 'sidecar',
+        image: 'sidecar:v2',
+      }],
+    }],
+  };
+
+  const rules = {
+    spec: deep({
+      containers: deepWithKey('name'),
+    }),
+  };
+
+  expect(() => mergeFull(pod, sidecarImageNotObject, rules)).toThrow();
+});
+
+test('deepWithKey: throw on wrong input type', () => {
+  const sidecarImageNotArray = {
+    spec: {
+      containers: {
+        name: 'sidecar',
+        image: 'sidecar:v2',
+      },
+    },
+  };
+
+  const rules = {
+    spec: deep({
+      containers: deepWithKey('name'),
+    }),
+  };
+
+  expect(() => mergeFull(pod, sidecarImageNotArray, rules)).toThrow();
+});
+
 test('first: basic', () => {
   const result = mergeFull(pod, sidecarImage, {
     spec: {


### PR DESCRIPTION
I used the wrong type by mistake and ended up with an internal stacktrace. With
this we make sure to throw a human readable error when the user provides the
erroenous input types.

Fixes: #246