### PR TITLE
examples: Use path instead of file in generate arrays

### DIFF
--- a/examples/docker/template-literal-simple/dockerfile.js
+++ b/examples/docker/template-literal-simple/dockerfile.js
@@ -18,5 +18,5 @@ ENTRYPOINT /${service.name}
 // Instruct generate to produce a Dockerfile with the value returned by the
 // Dockerfile function.
 export default [
-  { file: 'Dockerfile', value: Dockerfile(input) },
+  { path: 'Dockerfile', value: Dockerfile(input) },
 ];

--- a/examples/docker/template-literal/dockerfile.js
+++ b/examples/docker/template-literal/dockerfile.js
@@ -6,5 +6,5 @@ const myService = {
 };
 
 export default [
-  { file: 'Dockerfile', value: Dockerfile(myService) },
+  { path: 'Dockerfile', value: Dockerfile(myService) },
 ];

--- a/examples/jk/handlebars/handlebars.js
+++ b/examples/jk/handlebars/handlebars.js
@@ -13,5 +13,5 @@ const template = handlebars.compile(source);
 const context = { title: 'My New Post', body: 'This is my first post!' };
 
 export default [
-  { file: 'index.html', value: template(context) },
+  { path: 'index.html', value: template(context) },
 ];

--- a/examples/kubernetes/micro-service/micro-service.js
+++ b/examples/kubernetes/micro-service/micro-service.js
@@ -11,11 +11,11 @@ export function MicroService(service) {
   };
 
   return [
-    { file: `${ns}-ns.yaml`, value: k.Namespace(service) },
-    { file: `${ns}/${service.name}-deploy.yaml`, value: k.Deployment(service) },
-    { file: `${ns}/${service.name}-svc.yaml`, value: k.Service(service) },
-    { file: `${ns}/${service.name}-ingress.yaml`, value: k.Ingress(service) },
-    { file: `${ns}/${service.name}-dashboards-cm.yaml`, value: k.ConfigMap(service, `${service.name}-dashboards`, dashboards) },
-    { file: `${ns}/${service.name}-prometheus-rule.yaml`, value: PrometheusRule(service) },
+    { path: `${ns}-ns.yaml`, value: k.Namespace(service) },
+    { path: `${ns}/${service.name}-deploy.yaml`, value: k.Deployment(service) },
+    { path: `${ns}/${service.name}-svc.yaml`, value: k.Service(service) },
+    { path: `${ns}/${service.name}-ingress.yaml`, value: k.Ingress(service) },
+    { path: `${ns}/${service.name}-dashboards-cm.yaml`, value: k.ConfigMap(service, `${service.name}-dashboards`, dashboards) },
+    { path: `${ns}/${service.name}-prometheus-rule.yaml`, value: PrometheusRule(service) },
   ];
 }

--- a/examples/quick-start/alice/alice.js
+++ b/examples/quick-start/alice/alice.js
@@ -13,5 +13,5 @@ const alice = {
 
 // Instruct to write the alice object as a YAML file.
 export default [
-  { value: alice, file: `developers/${alice.name.toLowerCase()}.yaml` },
+  { value: alice, path: `developers/${alice.name.toLowerCase()}.yaml` },
 ];

--- a/examples/quick-start/terraform-github/github.js
+++ b/examples/quick-start/terraform-github/github.js
@@ -24,5 +24,5 @@ for (const dev of developers) {
 }
 
 export default [
-  { value: config, file: 'github.tf' },
+  { value: config, path: 'github.tf' },
 ];


### PR DESCRIPTION
path is the new file. Make sure to have our own examples follow that.

Fixes: #252