### PR TITLE
build: Add version 1.13 to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+go 1.13


### PR DESCRIPTION
The 1.13 toolchain keeps adding that to go.mod. Compiling with 1.12 still works
though. Let's just comply with what the 1.13 toolchain wants to do.