### PR TITLE
Port deferred.js to TypeScript

### DIFF
--- a/std/internal/data.ts
+++ b/std/internal/data.ts
@@ -1,7 +1,6 @@
-export type Data = Uint8Array | string;
-export type Transform = (x: Data) => Data;
+export type Transform = (x: Uint8Array) => any;
 
-export const ident : Transform = (x: Data): Data => x;
+export const ident : Transform = (x: Uint8Array): any => x;
 
 function uint8ToUint16Array(bytes: Uint8Array): Uint16Array {
   return new Uint16Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 2);

--- a/std/internal/rpc.ts
+++ b/std/internal/rpc.ts
@@ -5,6 +5,7 @@
 import { __std } from './__std_generated';
 import { flatbuffers } from './flatbuffers';
 import { sendRequest, requestAsPromise } from './deferred';
+import { ident } from './data';
 
 function encode(method: string, args: any[], sync: boolean): ArrayBuffer {
   const builder = new flatbuffers.Builder(512);
@@ -49,7 +50,7 @@ function encode(method: string, args: any[], sync: boolean): ArrayBuffer {
 
 // An asynchronous RPC call
 export function RPC(method: string, ...args: any[]): Promise<Uint8Array> {
-  return requestAsPromise(() => sendRequest(encode(method, args, false)), (c: Uint8Array) => c);
+  return requestAsPromise(() => sendRequest(encode(method, args, false)), ident);
 }
 
 // A synchronous RPC call


### PR DESCRIPTION
To remove an annoying warning from the build, but also because types are good, this PR ports deferred.js to TypeScript.

In doing so, some ambiguity over how the data from runtime calls is handled gets cleared up. Prior to this, `read` and `internal/rpc` used types that were a bit fishy, but because they went via the untyped `deferred` module, TypeScript could not complain. This commit pins those types down: the post-processing transform _always_ goes from a Uint8Array -- i.e., the bytes -- to `any` (there's no need for them to compose, any more).
