### PR TITLE
Avoid failures due to null (rather than empty) file listings

### DIFF
--- a/pkg/std/fs.go
+++ b/pkg/std/fs.go
@@ -70,7 +70,7 @@ func directoryListing(base, rel string) (Directory, error) {
 		return infos[i].Name() < infos[j].Name()
 	})
 
-	var files []FileInfo
+	files := make([]FileInfo, 0, len(infos))
 
 	for i := range infos {
 		if infos[i].IsDir() || infos[i].Mode().IsRegular() {

--- a/tests/fs-empty-dir-files/index.js
+++ b/tests/fs-empty-dir-files/index.js
@@ -1,0 +1,3 @@
+import { dir } from '@jkcfg/std/fs';
+
+dir('./empty');

--- a/tests/test-fs-empty-dir.js.cmd
+++ b/tests/test-fs-empty-dir.js.cmd
@@ -1,0 +1,3 @@
+rm -rf ./fs-empty-dir-files/empty
+mkdir -p ./fs-empty-dir-files/empty
+jk run -i ./fs-empty-dir-files ./fs-empty-dir-files/index.js


### PR DESCRIPTION
In the return value of `@jkcfg/std/fs#dir`, it's reasonable to assume that even if a directory is empty, you will get an iterable collection of files to loop over. Previously, though, the value was initialised to `nil`, which became `null` in JSON.