### PR TITLE
Allow '=' in parameter values

### DIFF
--- a/params_option.go
+++ b/params_option.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -50,10 +49,7 @@ func (p *paramsOption) setFromFile(s string) error {
 }
 
 func (p *paramsOption) setFromCommandline(s string) error {
-	parts := strings.Split(s, "=")
-	if len(parts) != 2 {
-		return errors.New("input parameters are of the form name=value")
-	}
+	parts := strings.SplitN(s, "=", 2)
 	path := parts[0]
 	v := parts[1]
 

--- a/tests/test-params-parsing.js
+++ b/tests/test-params-parsing.js
@@ -1,0 +1,6 @@
+import * as std from '@jkcfg/std';
+import * as param from '@jkcfg/std/param';
+
+for (const name of ['foo.1', 'foo.2', 'foo.3', 'foo.4', 'foo.5', 'foo.6']) {
+  std.log(`${name}: ${param.String(name)}`);
+}

--- a/tests/test-params-parsing.js.cmd
+++ b/tests/test-params-parsing.js.cmd
@@ -1,0 +1,1 @@
+jk run ./test-params-parsing.js -p foo.1=bar.1 -p "foo.2=bar.2" -p 'foo.3=bar.3' -p foo.4="bar.4" -p "foo.5=bar=5" -p 'foo.6=bar=6'

--- a/tests/test-params-parsing.js.expected
+++ b/tests/test-params-parsing.js.expected
@@ -1,0 +1,6 @@
+foo.1: bar.1
+foo.2: bar.2
+foo.3: bar.3
+foo.4: bar.4
+foo.5: bar=5
+foo.6: bar=6


### PR DESCRIPTION
This lets parameter values be any string (possibly requiring quoting).