### PR TITLE
Validate command

### DIFF
--- a/std/cmd/validate-exec.js
+++ b/std/cmd/validate-exec.js
@@ -1,0 +1,8 @@
+import validate from '@jkcfg/std/cmd/validate';
+
+const makeValidateFn = new Function(`
+  return (%s);
+`);
+
+const fn = makeValidateFn();
+validate(fn);

--- a/std/cmd/validate-module.js
+++ b/std/cmd/validate-module.js
@@ -1,0 +1,8 @@
+import validate from '@jkcfg/std/cmd/validate';
+import fn from '%s';
+
+if (typeof fn !== 'function') {
+  throw new Error('default export of given module is not a function');
+}
+
+validate(fn);

--- a/std/cmd/validate.ts
+++ b/std/cmd/validate.ts
@@ -1,0 +1,56 @@
+import * as std from '../index';
+import * as param from '../param';
+
+// ValidateResult is the canonical type of results for a validation
+// procedure.
+type ValidateResult = 'ok' | string[];
+
+// ValidateFnResult is the range of results we accept from an ad-hoc
+// procedure given to us.
+type ValidateFnResult = boolean | string | string[];
+type ValidateFn = (obj: any) => ValidateFnResult;
+
+function normaliseResult(result: ValidateFnResult): ValidateResult {
+  switch (typeof result) {
+  case 'string':
+    if (result === 'ok') return result;
+    return [result];
+  case 'boolean':
+    if (result) return 'ok';
+    return ['value not valid'];
+  case 'object':
+    if (Array.isArray(result)) return result;
+    break;
+  default:
+  }
+  throw new Error(`unrecognised result from validation function: ${result}`);
+}
+
+interface FileResult {
+  path: string;
+  result: ValidateResult;
+}
+
+export default function validate(fn: ValidateFn): void {
+  const inputFiles = param.Object('jk.validate.input', {});
+  const files = Object.keys(inputFiles);
+
+  const validateFile = async function vf(path: string): Promise<FileResult> {
+    const obj = await std.read(path);
+    return { path, result: normaliseResult(fn(obj)) };
+  };
+
+  const objects = files.map(validateFile);
+  Promise.all(objects).then((results): void => {
+    for (const { path, result } of results) {
+      if (result === 'ok') {
+        std.log(`${path}: ok`);
+      } else {
+        std.log(`${path}:`);
+        for (const err of result) {
+          std.log(`  error: ${err}`);
+        }
+      }
+    }
+  });
+}

--- a/tests/test-validate-exec.js.cmd
+++ b/tests/test-validate-exec.js.cmd
@@ -1,0 +1,1 @@
+jk validate -c 'v => v.name === "Valid"' ./validate-files/*.yaml

--- a/tests/test-validate-exec.js.expected
+++ b/tests/test-validate-exec.js.expected
@@ -1,0 +1,3 @@
+./validate-files/invalid.yaml:
+  error: value not valid
+./validate-files/valid.yaml: ok

--- a/tests/test-validate-module.js.cmd
+++ b/tests/test-validate-module.js.cmd
@@ -1,0 +1,1 @@
+jk validate -m ./validate-files/module ./validate-files/*.yaml

--- a/tests/test-validate-module.js.expected
+++ b/tests/test-validate-module.js.expected
@@ -1,0 +1,3 @@
+./validate-files/invalid.yaml:
+  error: object name is not "Valid"
+./validate-files/valid.yaml: ok

--- a/tests/validate-files/invalid.yaml
+++ b/tests/validate-files/invalid.yaml
@@ -1,0 +1,4 @@
+name: Invalid
+any:
+- other
+- garbage

--- a/tests/validate-files/module.js
+++ b/tests/validate-files/module.js
@@ -1,0 +1,4 @@
+export default function validate(obj) {
+  if (obj.name === 'Valid') return true;
+  return 'object name is not "Valid"';
+}

--- a/tests/validate-files/valid.yaml
+++ b/tests/validate-files/valid.yaml
@@ -1,0 +1,3 @@
+name: Valid
+other:
+  stuff: here

--- a/validate.go
+++ b/validate.go
@@ -18,6 +18,14 @@ var validateCmd = &cobra.Command{
 }
 
 const validateExamples = `
+  validating YAML files using a module's default export
+    jk validate -m '@example.com/validate' *.{yaml,yml}
+
+  validating YAMLs and JSONs using a local script's default export
+    jk validate ./valid.js *.{yaml,yml,json}
+
+  validating a specific file with an inline validation function
+    jk validate -c 'v => v.name === "correctName"' config.json
 `
 
 var validateOptions struct {

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jkcfg/jk/pkg/std"
+)
+
+var validateCmd = &cobra.Command{
+	Use:     "validate <file>...",
+	Example: validateExamples,
+	Short:   "Validate configuration files",
+	Args:    validateArgs,
+	Run:     validate,
+}
+
+const validateExamples = `
+`
+
+var validateOptions struct {
+	vmOptions
+	scriptOptions
+}
+
+func init() {
+	initScriptFlags(validateCmd, &validateOptions.scriptOptions)
+	initExecFlags(validateCmd, &validateOptions.vmOptions)
+	jk.AddCommand(validateCmd)
+}
+
+func validateArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("validate requires a script and at least one file")
+	}
+	return nil
+}
+
+func validate(cmd *cobra.Command, args []string) {
+	vm := newVM(&validateOptions.vmOptions)
+	vm.SetWorkingDirectory(".")
+
+	inputs := make(map[string]interface{})
+	for _, f := range args[:1] {
+		inputs[f] = f
+	}
+	vm.parameters.Set("jk.validate.input", inputs)
+
+	var module string
+	switch {
+	case validateOptions.inline:
+		module = fmt.Sprintf(string(std.Module("internal/validate-exec.js")), args[0])
+	default:
+		module = fmt.Sprintf(string(std.Module("internal/validate-module.js")), args[0])
+	}
+	if err := vm.Run("<validate>", module); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -43,7 +43,7 @@ func validate(cmd *cobra.Command, args []string) {
 	vm.SetWorkingDirectory(".")
 
 	inputs := make(map[string]interface{})
-	for _, f := range args[:1] {
+	for _, f := range args[1:] {
 		inputs[f] = f
 	}
 	vm.parameters.Set("jk.validate.input", inputs)
@@ -51,11 +51,11 @@ func validate(cmd *cobra.Command, args []string) {
 	var module string
 	switch {
 	case validateOptions.inline:
-		module = fmt.Sprintf(string(std.Module("internal/validate-exec.js")), args[0])
+		module = fmt.Sprintf(string(std.Module("cmd/validate-exec.js")), args[0])
 	default:
-		module = fmt.Sprintf(string(std.Module("internal/validate-module.js")), args[0])
+		module = fmt.Sprintf(string(std.Module("cmd/validate-module.js")), args[0])
 	}
-	if err := vm.Run("<validate>", module); err != nil {
+	if err := vm.Run("@jkcfg/std/cmd/<validate>", module); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
```
$ jk help validate
Validate configuration files

Usage:
  jk validate <file>... [flags]

Examples:

  validating YAML files using a module's default export
    jk validate -m '@example.com/validate' *.{yaml,yml}

  validating YAMLs and JSONs using a local script's default export
    jk validate ./valid.js *.{yaml,yml,json}

  validating a specific file with an inline validation function
    jk validate -c 'v => v.name === "correctName"' config.json


Flags:
  -d, --emit-dependencies         emit script dependencies
  -c, --exec                      treat first argument as specifying literal JavaScript to execute
  -h, --help                      help for validate
  -m, --module                    treat first argument as specifying a module to load
  -o, --output-directory string   where to output generated files
  -p, --parameter name=value      set input parameters
  -f, --parameters filename       load parameters from a JSON or YAML file
  -v, --verbose                   verbose output
```

Fixes: #235 