### PR TITLE
Distinguish between logging to stderr and ad-hoc printing to stdout

### DIFF
--- a/examples/jk/lodash/lodash.js
+++ b/examples/jk/lodash/lodash.js
@@ -1,5 +1,5 @@
-import { log } from '@jkcfg/std';
+import { print } from '@jkcfg/std';
 import _ from 'lodash-es';
 
-log(_.defaults({ a: 1 }, { a: 3, b: 2 }));
-log(_.partition([1, 2, 3, 4], n => n % 2));
+print(_.defaults({ a: 1 }, { a: 3, b: 2 }));
+print(_.partition([1, 2, 3, 4], n => n % 2));

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/google/flatbuffers v1.10.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2
+	github.com/jkcfg/v8worker2 v0.0.0-20191022163158-90e467066938
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2 h1:yroXZIO0q4uBioF+qxfrstz58/0kCKGJsBFd1Vd2OYg=
 github.com/jkcfg/v8worker2 v0.0.0-20190228210604-6677fe93c5c2/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
+github.com/jkcfg/v8worker2 v0.0.0-20191022163158-90e467066938 h1:5P29UIxG4BovHtyzcSarjn6sM0B54GhO2AU/T50Pr3s=
+github.com/jkcfg/v8worker2 v0.0.0-20191022163158-90e467066938/go.mod h1:V1TBZ48loRvHpVCQEQSt39QYggAjIWgCaA63Z7NuGPI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/std/index.ts
+++ b/std/index.ts
@@ -1,4 +1,9 @@
 export { log } from './log';
-export { Format, Overwrite, write } from './write';
+export {
+  Format,
+  Overwrite,
+  write,
+  print,
+} from './write';
 export { Encoding, read } from './read';
 export { parse, stringify } from './parse';

--- a/std/log.ts
+++ b/std/log.ts
@@ -2,12 +2,14 @@
  * @module std
  */
 
-import { write, WriteOptions } from './write';
-
-export function log(value: any, options?: WriteOptions): void {
+export function log(value: any): void {
   if (value === undefined) {
-    V8Worker2.print('undefined');
+    V8Worker2.log('undefined');
     return;
   }
-  write(value, '', options);
+  if (typeof value === 'string') {
+    V8Worker2.log(value);
+    return;
+  }
+  V8Worker2.log(JSON.stringify(value));
 }

--- a/std/v8worker.d.ts
+++ b/std/v8worker.d.ts
@@ -1,5 +1,6 @@
 declare namespace V8Worker2 {
   function print(...args: any[]): void;
+  function log(arg: any): void;
   type RecvCallback = (ab: ArrayBuffer) => void;
   function recv(cb: RecvCallback): void;
   function send(ab: ArrayBuffer): null | ArrayBuffer;

--- a/std/write.ts
+++ b/std/write.ts
@@ -69,3 +69,12 @@ export function write(value: any, path = '', { format = Format.FromExtension, in
   const resp = __std.Error.getRootAsError(data);
   throw new Error(resp.message());
 }
+
+// print is a convenience for printing any value to stdout
+export function print(value: any, opts: WriteOptions): void {
+  if (value === undefined) {
+    write('undefined\n', '', { format: Format.Raw });
+    return;
+  }
+  write(value, '', opts);
+}

--- a/tests/print-and-log.js
+++ b/tests/print-and-log.js
@@ -1,0 +1,10 @@
+export default function doTest(output) {
+  // We can print basic types.
+  output(1.2);
+  output('foo');
+  output(undefined);
+  output(null);
+
+  // We can print an object to stderr.
+  output({ kind: 'Bar', foo: 1.2 });
+}

--- a/tests/test-debug-rpc.js
+++ b/tests/test-debug-rpc.js
@@ -1,11 +1,11 @@
 import { echo } from '@jkcfg/std/debug';
-import { log } from '@jkcfg/std';
+import { print } from '@jkcfg/std';
 
-echo().then(log);
+echo().then(print);
 
 const arr = new Uint8Array(new ArrayBuffer(3));
 arr[0] = 1;
 arr[1] = 2;
 arr[2] = 3;
 
-echo(65, arr, 'string', { object: 'object' }).then(log);
+echo(65, arr, 'string', { object: 'object' }).then(print);

--- a/tests/test-debug-rpcsync.js
+++ b/tests/test-debug-rpcsync.js
@@ -1,11 +1,11 @@
 import { echoSync } from '@jkcfg/std/debug';
-import { log } from '@jkcfg/std';
+import { print } from '@jkcfg/std';
 
-log(echoSync());
+print(echoSync());
 
 const arr = new Uint8Array(new ArrayBuffer(3));
 arr[0] = 1;
 arr[1] = 2;
 arr[2] = 3;
 
-log(echoSync(65, arr, 'string', { object: 'object' }));
+print(echoSync(65, arr, 'string', { object: 'object' }));

--- a/tests/test-fs-walk-preorder.js
+++ b/tests/test-fs-walk-preorder.js
@@ -1,9 +1,9 @@
 import { walk } from '@jkcfg/std/fs';
-import { log } from '@jkcfg/std';
+import { print } from '@jkcfg/std';
 
 // The files and directories in fs-walk-preorder-files are designed to
 // be in alphabetical order, when traversed in preorder.
 
 for (const f of walk('./fs-walk-preorder-files')) {
-  if (!f.name.startsWith('.')) log(f.name);
+  if (!f.name.startsWith('.')) print(f.name);
 }

--- a/tests/test-jsonstream.js
+++ b/tests/test-jsonstream.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 
 const value = std.read('./test-jsonstream.js.expected', { format: std.Format.JSONStream });
-value.then(v => std.log(v, { format: std.Format.JSONStream }));
+value.then(v => std.write(v, '', { format: std.Format.JSONStream }));

--- a/tests/test-log.js
+++ b/tests/test-log.js
@@ -1,20 +1,4 @@
 import * as std from '@jkcfg/std';
+import doTest from './print-and-log';
 
-// We can print basic types to stdout.
-std.log(1.2);
-std.log('foo');
-std.log(undefined);
-std.log(null);
-
-// We can print an object to stdout.
-std.log({ kind: 'Bar', foo: 1.2 });
-
-// And tune the output indentation
-std.log({ kind: 'Bar', foo: 1.2 }, { indent: 4 });
-
-// Key order is deterministic.
-std.log({ foo: 1.2, kind: 'Bar' });
-
-// Same, but in YAML
-std.log({ kind: 'Bar', foo: { number: 1.2, string: 'mystring' } }, { format: std.Format.YAML });
-std.log({ foo: { number: 1.2, string: 'mystring' }, kind: 'Bar' }, { format: std.Format.YAML });
+doTest(std.log);

--- a/tests/test-log.js.expected
+++ b/tests/test-log.js.expected
@@ -2,23 +2,4 @@
 foo
 undefined
 null
-{
-  "foo": 1.2,
-  "kind": "Bar"
-}
-{
-    "foo": 1.2,
-    "kind": "Bar"
-}
-{
-  "foo": 1.2,
-  "kind": "Bar"
-}
-foo:
-  number: 1.2
-  string: mystring
-kind: Bar
-foo:
-  number: 1.2
-  string: mystring
-kind: Bar
+{"kind":"Bar","foo":1.2}

--- a/tests/test-module-resource.js
+++ b/tests/test-module-resource.js
@@ -3,4 +3,4 @@ import resource1 from './test-module-resource/resource';
 import resource2 from './test-module-resource/submodule/resource';
 import contents from './test-module-resource/fs';
 
-Promise.all([resource1, resource2, contents]).then(resources => resources.forEach(std.log));
+Promise.all([resource1, resource2, contents]).then(resources => resources.forEach(std.print));

--- a/tests/test-params-from-file.js
+++ b/tests/test-params-from-file.js
@@ -12,9 +12,9 @@ const o = param.Object('myObject', {
   },
 });
 
-std.log({
+std.write({
   myBoolean: b,
   myNumber: n,
   myString: s,
   myObject: o,
-});
+}, '');

--- a/tests/test-params-from-yaml.js
+++ b/tests/test-params-from-yaml.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 import * as param from '@jkcfg/std/param';
 
-std.log(param.String('config.message', 'fail'));
+std.write(param.String('config.message', 'fail'), '');

--- a/tests/test-params-issue-122.js
+++ b/tests/test-params-issue-122.js
@@ -2,4 +2,4 @@ import * as std from '@jkcfg/std';
 import * as param from '@jkcfg/std/param';
 
 const values = param.Object('values');
-std.log(values);
+std.write(values, '');

--- a/tests/test-params-override.js
+++ b/tests/test-params-override.js
@@ -12,7 +12,7 @@ const o = param.Object('myObject', {
   },
 });
 
-std.log({
+std.print({
   myBoolean: b,
   myNumber: n,
   myString: s,

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -5,7 +5,7 @@ const b = param.Boolean('myBoolean', false);
 const n = param.Number('myNumber', 3.14);
 const s = param.String('myString', 'foo');
 
-std.log({
+std.print({
   myBoolean: b,
   myNumber: n,
   myString: s,
@@ -24,7 +24,7 @@ const oD = param.Object('myObjectD', {
   },
 });
 
-std.log({
+std.print({
   myBoolean: bD,
   myNumber: nD,
   myString: sD,

--- a/tests/test-parse.js
+++ b/tests/test-parse.js
@@ -1,10 +1,10 @@
-import { parse, log, Format } from '@jkcfg/std';
+import { parse, print, Format } from '@jkcfg/std';
 
 const json = parse('{ "json" : "ok" }', Format.JSON);
-log(json);
+print(json);
 
 const yaml = parse('yaml: ok', Format.YAML);
-log(yaml);
+print(yaml);
 
 const yamls = parse(`
 ---
@@ -12,4 +12,4 @@ foo: 1
 ---
 bar: 2`, Format.YAMLStream);
 
-log(yamls);
+print(yamls);

--- a/tests/test-print.js
+++ b/tests/test-print.js
@@ -1,0 +1,15 @@
+import { print, Format } from '@jkcfg/std';
+import doTest from './print-and-log';
+
+doTest(print);
+
+// And tune the output indentation
+print({ kind: 'Bar', foo: 1.2 }, { indent: 4 });
+
+// Key order is deterministic.
+print({ kind: 'Bar', foo: 1.2 });
+print({ foo: 1.2, kind: 'Bar' });
+
+// Objects, but in YAML
+print({ kind: 'Bar', foo: { number: 1.2, string: 'mystring' } }, { format: Format.YAML });
+print({ foo: { number: 1.2, string: 'mystring' }, kind: 'Bar' }, { format: Format.YAML });

--- a/tests/test-print.js.expected
+++ b/tests/test-print.js.expected
@@ -1,0 +1,28 @@
+1.2
+foo
+undefined
+null
+{
+  "foo": 1.2,
+  "kind": "Bar"
+}
+{
+    "foo": 1.2,
+    "kind": "Bar"
+}
+{
+  "foo": 1.2,
+  "kind": "Bar"
+}
+{
+  "foo": 1.2,
+  "kind": "Bar"
+}
+foo:
+  number: 1.2
+  string: mystring
+kind: Bar
+foo:
+  number: 1.2
+  string: mystring
+kind: Bar

--- a/tests/test-run-dependencies.js
+++ b/tests/test-run-dependencies.js
@@ -1,5 +1,5 @@
 import * as std from '@jkcfg/std';
 import { foo } from './test-run-dependencies/failure';
 
-std.log(foo);
+std.print(foo);
 std.read('test-run-dependencies/svc-myapp.yaml');

--- a/tests/test-stdin.js
+++ b/tests/test-stdin.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 
 std.read('', { format: std.Format.JSONStream })
-  .then(v => std.log(v, { format: std.Format.YAMLStream }));
+  .then(v => std.write(v, '', { format: std.Format.YAMLStream }));

--- a/tests/test-yamlstream.js
+++ b/tests/test-yamlstream.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 
 const value = std.read('./test-yamlstream.js.expected', { format: std.Format.YAMLStream });
-value.then(v => std.log(v, { format: std.Format.YAMLStream }));
+value.then(v => std.print(v, { format: std.Format.YAMLStream }));

--- a/tests/validate-schema.js
+++ b/tests/validate-schema.js
@@ -1,4 +1,4 @@
-import { read, log } from '@jkcfg/std';
+import { read, print } from '@jkcfg/std';
 import { validateWithObject, validateWithFile } from '@jkcfg/std/schema';
 import validate from './validate-schema-files/module';
 
@@ -8,13 +8,13 @@ function stringifyResult(result) {
 }
 
 export default async function doTest(value) {
-  log('Object:');
+  print('Object:');
   const schema = await read('./validate-schema-files/person.json');
-  log(stringifyResult(validateWithObject(value, schema)));
+  print(stringifyResult(validateWithObject(value, schema)));
 
-  log('File:');
-  log(stringifyResult(await validateWithFile(value, 'validate-schema-files/person.json')));
+  print('File:');
+  print(stringifyResult(await validateWithFile(value, 'validate-schema-files/person.json')));
 
-  log('Module:');
-  log(stringifyResult(await validate(value)));
+  print('Module:');
+  print(stringifyResult(await validate(value)));
 }

--- a/vm.go
+++ b/vm.go
@@ -61,8 +61,8 @@ func initAllVMFlags(cmd *cobra.Command, opts *vmOptions) {
 
 const errorHandler = `
 function onerror(msg, src, line, col, err) {
-  V8Worker2.print("Promise rejected at", src, line + ":" + col);
-  V8Worker2.print(err.stack);
+  V8Worker2.log("Promise rejected at", src, line + ":" + col);
+  V8Worker2.log(err.stack);
 }
 `
 


### PR DESCRIPTION
Aims:

 - output runtime errors, traces, and so on to stderr so they can be treated separate from "deliberate" output
 - give JavaScript authors the ability to do the same in libraries and scripts
 - Fix #280

This PR:

 - Makes sure runtime stuff is output to stderr (in part by updating the V8Worker2 dependency)
 - Makes `std.log` output to stderr, by using (the new method) `V8Worker2.log`
 - Adds `std.print` which fills much the same purpose as `std.log` did -- it's a casual way to output values

Aside from outputting to stderr, `std.log` behaves a bit differently, since it doesn't go through `write`. There's no formatting options -- strings get printed as-is, and anything else goes through `JSON.stringify` (which by default, keeps everything on one line). This is better suited to logging output, I reckon.

An alternative would be to keep `std.log` as it is, and give people another procedure for printing to stderr. I felt that `log` strongly suggests logging output, which comes with the expectation of output to stderr, and it was better to correct that now than have to keep explaining it.