### PR TITLE
Avoid unused var warning in fs.ts

### DIFF
--- a/std/fs.ts
+++ b/std/fs.ts
@@ -60,7 +60,7 @@ export function join(base: string, name: string): string {
   return `${base}/${name}`;
 }
 
-const always = (_: FileInfo): boolean => true;
+const always = (): boolean => true;
 const noop = (): void => {};
 
 interface WalkOpts {


### PR DESCRIPTION
Removes a warning from eslint over an unused var, that is provoked by having a function that ignores its argument (which was declared for the sake of showing that it will normally be given an argument ..)