### PR TITLE
Port generate.js and transform.js to TypeScript

### DIFF
--- a/std/generate.ts
+++ b/std/generate.ts
@@ -1,4 +1,20 @@
-import * as std from '@jkcfg/std';
+import * as std from './index';
+
+/* eslint @typescript-eslint/explicit-function-return-type: "off" */
+
+type ValidateFn = (value: any) => string;
+
+export interface Value {
+  path: string;
+  value: any | Promise<any>;
+  format?: std.Format;
+  validate?: ValidateFn;
+}
+
+export interface GenerateParams {
+  stdout?: boolean;
+  overwrite?: std.Overwrite;
+}
 
 const helpMsg = `
 To use generate, export a default value with the list of files to generate:
@@ -14,11 +30,11 @@ Notes:
 - The default export can also be a promise to such a array.
 - Optional parameters are the same as std.write().`;
 
-function error(msg) {
+function error(msg: string): void {
   std.log(`error: ${msg}`);
 }
 
-function help() {
+function help(): void {
   std.log(helpMsg);
 }
 
@@ -29,7 +45,7 @@ function help() {
  * @returns {number} res
  * @private
  */
-function mod(x, y) {
+function mod(x: number, y: number): number {
   if (y > 0) {
     // We don't use JavaScript's modulo operator here as this doesn't work
     // correctly for x < 0 and x === 0
@@ -45,18 +61,18 @@ function mod(x, y) {
 
 // https://stackoverflow.com/questions/13627308/add-st-nd-rd-and-th-ordinal-suffix-to-a-number/13627586
 // We don't use the modulo operator here as it would be interpreted by Sprintf.
-const nth = (n) => {
+const nth = (n: number): string => {
   const s = ['th', 'st', 'nd', 'rd'];
 
   const v = mod(n, 100);
   return n + (s[mod(v - 20, 10)] || s[v] || s[0]);
 };
 
-function extension(path) {
+function extension(path: string): string {
   return path.split('.').pop();
 }
 
-function formatFromPath(path) {
+function formatFromPath(path: string): std.Format {
   switch (extension(path)) {
   case 'yaml':
   case 'yml':
@@ -71,10 +87,18 @@ function formatFromPath(path) {
   }
 }
 
-const isString = s => typeof s === 'string' || s instanceof String;
+const isString = (s: any): boolean => typeof s === 'string' || s instanceof String;
+
+// represents a value that has has any promises resolved
+interface RealisedValue {
+  value: any;
+  format?: std.Format;
+  file?: string;
+  path?: string;
+}
 
 // Compute the output format of a value.
-function valueFormat(o) {
+function valueFormat(o: RealisedValue): std.Format {
   let { path, format, value } = o;
 
   if (format === undefined || format === std.Format.FromExtension) {
@@ -88,10 +112,10 @@ function valueFormat(o) {
   return format;
 }
 
-function formatSummary(value) {
+function formatSummary(values: RealisedValue[]): number[] {
   const formats = Array(Object.keys(std.Format).length).fill(0);
 
-  value.forEach((e) => {
+  values.forEach((e): void => {
     formats[valueFormat(e)] += 1;
   });
 
@@ -108,9 +132,9 @@ const formatNames = [
   'HCL',
 ];
 
-const formatName = f => formatNames[f];
+const formatName = (f: std.Format): string => formatNames[f];
 
-function usedFormats(summary) {
+function usedFormats(summary: number[]): string[] {
   const augmented = summary.map((n, i) => ({ format: formatName(i), n }));
   return augmented.reduce((formats, desc) => {
     if (desc.n > 0) {
@@ -120,16 +144,16 @@ function usedFormats(summary) {
   }, []);
 }
 
-function validate(value, params) {
+function validate(values: RealisedValue[], params: GenerateParams) {
   /* we have an array */
-  if (!Array.isArray(value)) {
+  if (!Array.isArray(values)) {
     error('default value is not an array');
     return { valid: false, showHelp: true };
   }
 
   /* an array with each element a { path, value } object */
   let valid = true;
-  value.forEach((e, i) => {
+  values.forEach((e, i) => {
     /* 'file' is the old 'path' property name. Fixup things */
     if (e.file !== undefined) {
       e.path = e.file;
@@ -143,7 +167,7 @@ function validate(value, params) {
     });
   });
 
-  if (valid === false) {
+  if (!valid) {
     return { valid, showHelp: true };
   }
 
@@ -151,7 +175,7 @@ function validate(value, params) {
   let stdoutFormat;
   if (params.stdout === true) {
     /* there's a single output format defined */
-    const summary = formatSummary(value);
+    const summary = formatSummary(values);
     const formats = usedFormats(summary);
     if (formats.length > 1) {
       error(`stdout output requires using a single format but got: ${formats.join(',')}`);
@@ -162,45 +186,49 @@ function validate(value, params) {
      * If we have more than one file to generate, make sure it's either JSON or
      * YAML so we can output a stream of documents.
      */
-    if (value.length > 1 && formats[0] !== 'JSON' && formats[0] !== 'YAML') {
+    if (values.length > 1 && formats[0] !== 'JSON' && formats[0] !== 'YAML') {
       error(`stdout output for multiple files requires either JSON or YAML format but got: ${formats[0]}`);
       return { valid: false, showHelp: false };
     }
 
-    if (value.length > 1) {
+    if (values.length > 1) {
       if (formats[0] === 'JSON') {
         stdoutFormat = std.Format.JSONStream;
       } else if (formats[0] === 'YAML') {
         stdoutFormat = std.Format.YAMLStream;
       }
     } else {
-      stdoutFormat = valueFormat(value[0]);
+      stdoutFormat = valueFormat(values[0]);
     }
   }
 
   return { valid: true, stdoutFormat, showHelp: false };
 }
 
+type ValueArg = Value[] | Promise<Value[]> | (() => Value[]);
 
-function generate(defaultExport, params) {
+function generate(definition: ValueArg, params: GenerateParams) {
   /*
    * The default export can be:
    *  1. an array of { path, value } objects,
    *  2. a promise to such an array,
    *  3. a function evaluating to either 1. or 2.
    */
-  let definition = defaultExport;
+  let inputs: Promise<Value[]>;
   if (typeof definition === 'function') {
-    definition = definition();
+    inputs = Promise.resolve(definition());
+  } else {
+    inputs = Promise.resolve(definition);
   }
 
   const { stdout = false, overwrite = false } = params;
 
-  Promise.resolve(definition).then((files) => {
+  inputs.then((files) => {
     /* values can be promises as well */
-    const values = files.map(f => f.value);
-    Promise.all(values).then((resolved) => {
+    const justValues = files.map(f => f.value);
+    Promise.all(justValues).then((resolved) => {
       resolved.forEach((v, i) => {
+        // eslint-disable-next-line no-param-reassign
         files[i].value = v;
       });
 
@@ -214,10 +242,9 @@ function generate(defaultExport, params) {
 
       if (stdout) {
         if (files.length > 1) {
-          const values = files.map(f => f.value);
-          std.write(values, '', { format: stdoutFormat });
+          std.write(justValues, '', { format: stdoutFormat });
         } else {
-          std.write(files[0].value, '', { format: stdoutFormat });
+          std.write(justValues[0], '', { format: stdoutFormat });
         }
       } else {
         for (const o of files) {


### PR DESCRIPTION
Since these are in effect public modules, they ought to have
TypeScript definitions, and the simplest (ha) way to do that is to
rewrite them in TypeScript.