### PR TITLE
Move cmd modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,16 @@ pkg/__std/lib/assets_vfsdata.go: std/internal/__std_generated.ts std/dist/index.
 std/internal/__std_generated.ts: std/internal/*.fbs std/package.json std/generate.sh
 	std/generate.sh
 
-std_sources = std/*.js std/*.ts std/internal/*.ts std/internal/*.js
+std_sources = std/*.js std/*.ts std/internal/*.ts std/internal/*.js std/cmd/*.ts std/cmd/*.js
 
 std/dist/index.js: $(std_sources)
+	rm -rf ./std/dist
+	mkdir -p std/dist
 	cd std && npm run build
 
 module = @jkcfg/std
 module: $(module)/package.json
-$(module)/package.json: std/*.js std/*.ts std/internal/__std_generated.ts std/package.json
+$(module)/package.json: $(std_sources) std/internal/__std_generated.ts std/package.json
 	cd std && npx tsc --outDir ../$(module)
 	cd std && npx tsc --declaration --emitDeclarationOnly --allowJs false --outdir ../$(module) || true
 	cp README.md LICENSE std/package.json std/internal/flatbuffers.d.ts $(module)

--- a/generate.go
+++ b/generate.go
@@ -72,7 +72,7 @@ func generate(cmd *cobra.Command, args []string) {
 	vm.parameters.SetBool("jk.generate.stdout", generateOptions.stdout)
 	vm.SetWorkingDirectory(".")
 
-	if err := vm.Run("<generate>", fmt.Sprintf(string(std.Module("internal/generate-module.js")), args[0])); err != nil {
+	if err := vm.Run("@jkcfg/std/cmd/<generate>", fmt.Sprintf(string(std.Module("cmd/generate-module.js")), args[0])); err != nil {
 		if !skipException(err) {
 			log.Fatal(err)
 		}

--- a/std/cmd/generate-module.js
+++ b/std/cmd/generate-module.js
@@ -1,5 +1,5 @@
 import * as param from '@jkcfg/std/param';
-import { generate } from '@jkcfg/std/generate';
+import { generate } from '@jkcfg/std/cmd/generate';
 import generateDefinition from '%s';
 
 const inputParams = {

--- a/std/cmd/generate.ts
+++ b/std/cmd/generate.ts
@@ -1,4 +1,4 @@
-import * as std from './index';
+import * as std from '../index';
 
 /* eslint @typescript-eslint/explicit-function-return-type: "off" */
 

--- a/std/cmd/transform-exec.js
+++ b/std/cmd/transform-exec.js
@@ -1,4 +1,4 @@
-import transform from '@jkcfg/std/transform';
+import transform from '@jkcfg/std/cmd/transform';
 
 const makeTransformFn = new Function(`
   return (%s);

--- a/std/cmd/transform-module.js
+++ b/std/cmd/transform-module.js
@@ -1,4 +1,4 @@
-import transform from '@jkcfg/std/transform';
+import transform from '@jkcfg/std/cmd/transform';
 import fn from '%s';
 
 if (typeof fn !== 'function') {

--- a/std/cmd/transform.ts
+++ b/std/cmd/transform.ts
@@ -1,5 +1,5 @@
-import * as std from './index';
-import * as param from './param';
+import * as std from '../index';
+import * as param from '../param';
 import { generate, Value, GenerateParams } from './generate';
 
 type TransformFn = (value: any) => any | void;

--- a/std/tsconfig.json
+++ b/std/tsconfig.json
@@ -22,6 +22,7 @@
     "excludeExternals": true,
     "externalPattern": [
       "internal/**/*.{ts,js}",
+      "cmd/**/*.{ts,js}",
       "docs/**/*.{ts,js}",
       "dist/**/*.{ts.js}",
       "index.ts"

--- a/transform.go
+++ b/transform.go
@@ -69,11 +69,11 @@ func transform(cmd *cobra.Command, args []string) {
 	var module string
 	switch {
 	case transformOptions.inline:
-		module = fmt.Sprintf(string(std.Module("internal/transform-exec.js")), args[0])
+		module = fmt.Sprintf(string(std.Module("cmd/transform-exec.js")), args[0])
 	default:
-		module = fmt.Sprintf(string(std.Module("internal/transform-module.js")), args[0])
+		module = fmt.Sprintf(string(std.Module("cmd/transform-module.js")), args[0])
 	}
-	if err := vm.Run("<transform>", module); err != nil {
+	if err := vm.Run("@jkcfg/std/cmd/<transform>", module); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/vm.go
+++ b/vm.go
@@ -176,7 +176,7 @@ func (vm *vm) resolver() *resolve.Resolver {
 		&resolve.MagicImporter{Specifier: "@jkcfg/std/resource", Generate: vm.resources.MakeModule},
 		&resolve.StdImporter{
 			// List here the modules users are allowed to access.
-			PublicModules: []string{"index.js", "param.js", "fs.js", "merge.js", "debug.js", "transform.js", "generate.js", "schema.js"},
+			PublicModules: []string{"index.js", "param.js", "fs.js", "merge.js", "debug.js", "schema.js"},
 		},
 		&resolve.FileImporter{},
 		&resolve.NodeImporter{ModuleBase: vm.scriptDir},


### PR DESCRIPTION
- move std/{generate,transform}.ts to std/cmd/, so they aren't
   included in e.g., docs;

 - move std/internal/{transform,generate}-module.js "entry point"
   templates to std/cmd, so they are with their companions;

 - give a @jkcfg/std path when loading the entry points, so they can
   import non-public modules

 - tell typedoc to ignore cmd/, similarly to internal/
