### PR TITLE
std: Introduce an Std object to carry the stdlib context

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -68,9 +68,8 @@ func generate(cmd *cobra.Command, args []string) {
 		generateOptions.inputDirectory = inputDir
 	}
 
-	vm := newVM(&generateOptions.vmOptions)
+	vm := newVM(&generateOptions.vmOptions, ".")
 	vm.parameters.SetBool("jk.generate.stdout", generateOptions.stdout)
-	vm.SetWorkingDirectory(".")
 
 	if err := vm.Run("@jkcfg/std/cmd/<generate>", fmt.Sprintf(string(std.Module("cmd/generate-module.js")), args[0])); err != nil {
 		if !skipException(err) {

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -29,8 +29,9 @@ type sender interface {
 // returned will be serialised to JSON.
 type RPCFunc func([]interface{}) (interface{}, error)
 
-// ExecuteOptions global input parameters to the standards library.
-type ExecuteOptions struct {
+// Options are global configuration options to tweak the behavior of the
+// standard library.
+type Options struct {
 	// Verbose indicates if some operations, such as write, should print out what
 	// they are doing.
 	Verbose bool
@@ -47,6 +48,18 @@ type ExecuteOptions struct {
 	// ExtMethods is where extension RPC methods are registered (the
 	// standard ones are here, and take precedence)
 	ExtMethods map[string]RPCFunc
+}
+
+// Std represents the standard library.
+type Std struct {
+	options Options
+}
+
+// NewStd creates a new instance of the standard library.
+func NewStd(options Options) *Std {
+	return &Std{
+		options: options,
+	}
 }
 
 // stdError builds an Error flatbuffer we can return to the javascript side.
@@ -100,7 +113,9 @@ func requireThreeStrings(fn func(string, string, string) (interface{}, error)) R
 }
 
 // Execute parses a message from v8 and execute the corresponding function.
-func Execute(msg []byte, res sender, options ExecuteOptions) []byte {
+func (std *Std) Execute(msg []byte, res sender) []byte {
+	options := std.options
+
 	message := __std.GetRootAsMessage(msg, 0)
 
 	union := flatbuffers.Table{}

--- a/run.go
+++ b/run.go
@@ -109,8 +109,7 @@ func establishScriptDir(opts scriptOptions, scriptArg string) string {
 
 func run(cmd *cobra.Command, args []string) {
 	scriptDir := establishScriptDir(runOptions.scriptOptions, args[0])
-	vm := newVM(&runOptions.vmOptions)
-	vm.SetWorkingDirectory(scriptDir)
+	vm := newVM(&runOptions.vmOptions, scriptDir)
 
 	var runErr error
 

--- a/transform.go
+++ b/transform.go
@@ -50,8 +50,7 @@ func transform(cmd *cobra.Command, args []string) {
 	// We must use the current directory as the working directory (for
 	// the purpose of resolving modules), because we're potentially
 	// going to supply a path _relative to here_ as an import.
-	vm := newVM(&transformOptions.vmOptions)
-	vm.SetWorkingDirectory(".")
+	vm := newVM(&transformOptions.vmOptions, ".")
 
 	// Encode the inputs as a map of path to .. the same path (for
 	// now). This is in part to get around the limitations of

--- a/validate.go
+++ b/validate.go
@@ -47,8 +47,7 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 }
 
 func validate(cmd *cobra.Command, args []string) {
-	vm := newVM(&validateOptions.vmOptions)
-	vm.SetWorkingDirectory(".")
+	vm := newVM(&validateOptions.vmOptions, ".")
 
 	inputs := make(map[string]interface{})
 	for _, f := range args[1:] {

--- a/vm.go
+++ b/vm.go
@@ -178,8 +178,6 @@ func (vm *vm) setWorkingDirectory(dir string) {
 }
 
 func (vm *vm) resolver() *resolve.Resolver {
-	// TODO(damien): there's an ugly dependency here. The user of the vm object has
-	// to call SetWorkingDir before being able to call Run* functions.
 	resolver := resolve.NewResolver(vm.worker, vm.scriptDir,
 		&resolve.MagicImporter{Specifier: "@jkcfg/std/resource", Generate: vm.resources.MakeModule},
 		&resolve.StdImporter{


### PR DESCRIPTION
I'd like to add state to the stdlib that persists between std.Execute() calls.
I could add global variables in pkg/std or introduce an object to carry that
state between Execute calls. Went for the latter.

This bit of refactoring will be very useful soon: I need to store
plugin-related state because I want plugins, which are somewhat expensive to
start as they are sub-processes, to be around for the duration of the Std
object.