### PR TITLE
Deal with promises returned from validation

### DIFF
--- a/std/cmd/validate.ts
+++ b/std/cmd/validate.ts
@@ -8,9 +8,10 @@ type ValidateResult = 'ok' | string[];
 // ValidateFnResult is the range of results we accept from an ad-hoc
 // procedure given to us.
 type ValidateFnResult = boolean | string | string[];
-type ValidateFn = (obj: any) => ValidateFnResult;
+type ValidateFn = (obj: any) => ValidateFnResult | Promise<ValidateFnResult>;
 
-function normaliseResult(result: ValidateFnResult): ValidateResult {
+async function normaliseResult(val: Promise<ValidateFnResult>): Promise<ValidateResult> {
+  const result = await val;
   switch (typeof result) {
   case 'string':
     if (result === 'ok') return result;
@@ -37,7 +38,8 @@ export default function validate(fn: ValidateFn): void {
 
   const validateFile = async function vf(path: string): Promise<FileResult> {
     const obj = await std.read(path);
-    return { path, result: normaliseResult(fn(obj)) };
+    const result = await normaliseResult(Promise.resolve(fn(obj)));
+    return { path, result };
   };
 
   const objects = files.map(validateFile);

--- a/tests/test-validate-promise.js.cmd
+++ b/tests/test-validate-promise.js.cmd
@@ -1,0 +1,1 @@
+jk validate -c 'v => Promise.resolve(v.name == "Valid")' ./validate-files/*.yaml

--- a/tests/test-validate-promise.js.expected
+++ b/tests/test-validate-promise.js.expected
@@ -1,0 +1,3 @@
+./validate-files/invalid.yaml:
+  error: value not valid
+./validate-files/valid.yaml: ok


### PR DESCRIPTION
Validation functions can and often will return a promise of a
result. The template script needs to be able to cope with that.