### PR TITLE
Cope with structured validation results, e.g., from schema validation

### DIFF
--- a/std/schema.ts
+++ b/std/schema.ts
@@ -4,29 +4,9 @@
 
 import { RPC, RPCSync } from './internal/rpc';
 import { valueFromUTF8Bytes } from './internal/data';
+import { ValidationResult } from './validation';
 
-// These two types could be put in a more general validation module
-// (along with convenience formatters), since they are generic.
-
-interface Location {
-  line: number;
-  column: number;
-}
-
-/**
- * ValidationError represents a specific problem encountered when
- * validating a value.
- */
-export interface ValidationError {
-  msg: string;
-  path?: string;
-  start?: Location;
-  end?: Location;
-}
-
-export type Result = 'ok' | ValidationError[];
-
-function decodeResponse(bytes: Uint8Array): Result {
+function decodeResponse(bytes: Uint8Array): ValidationResult {
   const results = valueFromUTF8Bytes(bytes);
   if (results === null) {
     return 'ok';
@@ -45,7 +25,7 @@ function decodeResponse(bytes: Uint8Array): Result {
  * const result = validateWithObject(5, { type: 'number' });
  * ```
  */
-export function validateWithObject(obj: any, schema: Record<string, any>): Result {
+export function validateWithObject(obj: any, schema: Record<string, any>): ValidationResult {
   return decodeResponse(RPCSync('std.validate.schema', JSON.stringify(obj), JSON.stringify(schema)));
 }
 
@@ -53,7 +33,7 @@ export function validateWithObject(obj: any, schema: Record<string, any>): Resul
  * validateWithFile validates a value using a schema located at
  * the path (relative to the input directory).
  */
-export function validateWithFile(obj: any, path: string): Promise<Result> {
+export function validateWithFile(obj: any, path: string): Promise<ValidationResult> {
   return RPC('std.validate.schemafile', JSON.stringify(obj), path, '').then(decodeResponse);
 }
 
@@ -71,6 +51,7 @@ export function validateWithFile(obj: any, path: string): Promise<Result> {
  * }
  * ```
  */
-export function validateWithResource(obj: any, path: string, moduleRef: string): Promise<Result> {
+export function validateWithResource(obj: any, path: string,
+                                     moduleRef: string): Promise<ValidationResult> {
   return RPC('std.validate.schemafile', JSON.stringify(obj), path, moduleRef).then(decodeResponse);
 }

--- a/std/validation.test.js
+++ b/std/validation.test.js
@@ -1,0 +1,29 @@
+import { formatError } from './validation';
+
+const justMsg = { msg: 'Just an error message' };
+test('just a message', () => {
+  expect(formatError('source.js', justMsg)).toEqual(`source.js: ${justMsg.msg}`);
+});
+
+const msgAndPath = { msg: 'This field was wrong', path: '<root>.foo.bar' };
+test('a message with a path', () => {
+  expect(formatError('source.js', msgAndPath)).toEqual(`source.js: ${msgAndPath.msg} at ${msgAndPath.path}`);
+});
+
+const msgStart = {
+  msg: 'The field here was wrong',
+  start: { line: 3, column: 20 },
+};
+test('message with start location', () => {
+  expect(formatError('source.js', msgStart)).toEqual(`source.js:3.20: ${msgStart.msg}`);
+});
+
+const all = {
+  msg: 'The field here was wrong',
+  path: '<root>.foo.bar',
+  start: { line: 3, column: 20 },
+  end: { line: 5, column: 0 },
+};
+test('', () => {
+  expect(formatError('source.js', all)).toEqual(`source.js:3.20-5.0: ${all.msg} at ${all.path}`);
+});

--- a/std/validation.ts
+++ b/std/validation.ts
@@ -1,0 +1,78 @@
+/**
+ * @module std/validation
+ */
+
+interface Location {
+  line: number;
+  column: number;
+}
+
+/**
+ * ValidationError represents a specific problem encountered when
+ * validating a value.
+ */
+export interface ValidationError {
+  msg: string;
+  path?: string;
+  start?: Location;
+  end?: Location;
+}
+
+function isValidationError(err: string | ValidationError): err is ValidationError {
+  return (typeof err === 'object' && 'msg' in err);
+}
+
+// ValidationResult is the canonical type of results for a validation
+// procedure.
+export type ValidationResult = 'ok' | ValidationError[];
+
+// ValidateFnResult is the range of results we accept from an ad-hoc
+// procedure given to us.
+export type ValidateFnResult = boolean | string | (string | ValidationError)[];
+
+function normaliseError(err: string | ValidationError): ValidationError {
+  if (typeof err === 'string') return { msg: err };
+  if (typeof err === 'object' && isValidationError(err)) return err;
+  throw new Error(`unrecognised result from validation function: ${err}`);
+}
+
+// normaliseResult maps from the accepted return values of a
+// validation function to the more restrictive `ValidateResult`, so
+// that results can be dealt with uniformly.
+export function normaliseResult(result: ValidateFnResult): ValidationResult {
+  switch (typeof result) {
+  case 'string':
+    if (result === 'ok') return result;
+    return [{ msg: result }];
+  case 'boolean':
+    if (result) return 'ok';
+    return [{ msg: 'value not valid' }];
+  case 'object':
+    if (Array.isArray(result)) return result.map(normaliseError);
+    if (isValidationError(result)) return [result];
+    break;
+  default:
+  }
+  throw new Error(`unrecognised result from validation function: ${result}`);
+}
+
+/**
+ * formatError formats a validation error in a standard way. Since the
+ * errors do not include the source, this must be supplied.
+ */
+export function formatError(source: string, err: ValidationError): string {
+  let out = err.msg;
+  if (err.path !== undefined) {
+    out = `${err.msg} at ${err.path}`;
+  }
+  if (err.start !== undefined) {
+    if (err.end !== undefined) {
+      out = `${err.start.line}.${err.start.column}-${err.end.line}.${err.end.column}: ${out}`;
+    } else {
+      out = `${err.start.line}.${err.start.column}: ${out}`;
+    }
+  } else { // if no location, put a spacer between the source file and message
+    out = ` ${out}`;
+  }
+  return `${source}:${out}`;
+}

--- a/tests/test-validate-exec.js.expected
+++ b/tests/test-validate-exec.js.expected
@@ -1,3 +1,2 @@
-./validate-files/invalid.yaml:
-  error: value not valid
+./validate-files/invalid.yaml: value not valid
 ./validate-files/valid.yaml: ok

--- a/tests/test-validate-module.js.expected
+++ b/tests/test-validate-module.js.expected
@@ -1,3 +1,2 @@
-./validate-files/invalid.yaml:
-  error: object name is not "Valid"
+./validate-files/invalid.yaml: object name is not "Valid"
 ./validate-files/valid.yaml: ok

--- a/tests/test-validate-promise.js.expected
+++ b/tests/test-validate-promise.js.expected
@@ -1,3 +1,2 @@
-./validate-files/invalid.yaml:
-  error: value not valid
+./validate-files/invalid.yaml: value not valid
 ./validate-files/valid.yaml: ok


### PR DESCRIPTION
This makes `jk validate` handle the structured results from schema validation, as well as the other things we might expect random validation functions to return. Fixes #296 