### PR TITLE
Multiple import paths

### DIFF
--- a/pkg/resolve/file_importer_test.go
+++ b/pkg/resolve/file_importer_test.go
@@ -1,0 +1,21 @@
+package resolve
+
+import (
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	fr := FileImporter{ModuleBase: "testfiles"}
+	_, path, _ := fr.Import(".", "./testfiles/foo", "<test>")
+	if path != "testfiles/foo.js" {
+		t.Errorf("did not resolve ./testfiles/foo, got %q", path)
+	}
+}
+
+func TestOutsideModuleBase(t *testing.T) {
+	fr := FileImporter{ModuleBase: "testfiles/pkg"}
+	_, path, _ := fr.Import(".", "testfiles/foo.js", "<test>")
+	if path != "" {
+		t.Errorf("should not resolve; but was resolved to %q", path)
+	}
+}

--- a/pkg/resolve/npm.go
+++ b/pkg/resolve/npm.go
@@ -59,7 +59,7 @@ by
 // algorithm adapted from Node.JS's, in order to support modules installed
 // with npm.
 type NodeImporter struct {
-	// ModulesPath is the top-level directory at which to stop looking
+	// ModuleBase is the top-level directory at which to stop looking
 	// for "module paths" (those that don't start with `/`, `./`, or
 	// `../`).
 	ModuleBase string
@@ -107,6 +107,12 @@ func (n *NodeImporter) loadGuessedFile(path string) ([]byte, string, []Candidate
 // loadAsPath attempts to load a path when it's unknown whether it
 // refers to a file or a directory.
 func (n *NodeImporter) loadAsPath(path string) ([]byte, string, []Candidate) {
+	// guard against paths that break out of the ModuleBase
+	rel, err := filepath.Rel(n.ModuleBase, path)
+	if err != nil || strings.HasPrefix(rel, "../") {
+		return nil, "", nil
+	}
+
 	bytes, resolvedPath, fileCandidates := n.loadAsFile(path)
 	if bytes != nil {
 		return bytes, resolvedPath, fileCandidates

--- a/pkg/resolve/resolver.go
+++ b/pkg/resolve/resolver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jkcfg/jk/pkg/record"
 )
 
-// This is how the module loading works with V8Worker: You can ask a
+// This is how the module loading works with V8Worker2: You can ask a
 // worker to load a module by calling `worker.LoadModule`. To this,
 // you have to supply the specifier for the module (the name that was
 // used to refer to it), the code in the module as a string, and a
@@ -26,10 +26,9 @@ import (
 //  - there's no worker passed in the callback, so it has to be in the
 //  closure, or otherwise accessed.
 //
-//  - the V8Worker code expects LoadModule to be called with the
+//  - the V8Worker2 code expects LoadModule to be called with the
 //  specifier it gave, otherwise it will treat it as a failure to load
-//  the module (NB this seems to mean you have to load a module
-//  referred to by different paths once for each path)
+//  the module
 //
 //  - the referrer for an import will be the previous specifier; this
 //  means you need to carry any directory context around with you,

--- a/tests/import-paths-files/from-module-path/index.js
+++ b/tests/import-paths-files/from-module-path/index.js
@@ -1,0 +1,1 @@
+export default 'value from module on module path';

--- a/tests/import-paths.js
+++ b/tests/import-paths.js
@@ -1,0 +1,4 @@
+import { log } from '@jkcfg/std';
+import value from 'from-module-path';
+
+log(value);

--- a/tests/test-generate-import-script-not-in-cwd/test.js
+++ b/tests/test-generate-import-script-not-in-cwd/test.js
@@ -1,4 +1,4 @@
-import { s } from 'test-string.js';
+import { s } from './test-string.js';
 import * as std from '@jkcfg/std';
 
 export default [

--- a/tests/test-import-path.js.cmd
+++ b/tests/test-import-path.js.cmd
@@ -1,0 +1,1 @@
+jk run -I ./import-paths-files import-paths.js

--- a/tests/test-import-path.js.expected
+++ b/tests/test-import-path.js.expected
@@ -1,0 +1,1 @@
+value from module on module path

--- a/vm.go
+++ b/vm.go
@@ -184,7 +184,7 @@ func (vm *vm) resolver() *resolve.Resolver {
 			// List here the modules users are allowed to access.
 			PublicModules: []string{"index.js", "param.js", "fs.js", "merge.js", "debug.js", "schema.js"},
 		},
-		&resolve.FileImporter{},
+		&resolve.FileImporter{ModuleBase: vm.scriptDir},
 		&resolve.NodeImporter{ModuleBase: vm.scriptDir},
 	)
 	resolver.SetRecorder(vm.recorder)


### PR DESCRIPTION
 - [x] make sure specifiers interpreted as relative paths don't break out of the base path
 - [x] allow multiple import paths to be supplied

> A natural implication is that if I use `-I ~/lib/jk`, then a module at
> `~/lib/jk/foo/index.js` can now be imported as `'import f from
> 'foo'`.

This deserves some elaboration. Prior to this PR, the effective module resolution rules were something like

 - if specifier is `@jkcfg/std[/something]` or a "magic" import, load from the runtime
 - otherwise:
   - (a) try treating it as a path relative to the importing module (or script being run, or $PWD)
   - (b) try treating it as a NPM module

The resolution (a) was done _both_ by FileImporter and NodeImporter, in nearly the same way. The only case which FileImporter covered which NodeImporter didn't was referring to a relative path _without_ using `./` or `../`.

But this wasn't suitable for the expected behaviour quoted above, since the FileImporter would never attempt to resolve relative to its own root path. So I have changed it to treat explicitly relative paths as relative, and other paths as based at its root.

There's good evidence that this will not cause too many problems:
 1. this is how NPM resolution (that implemented in Node.JS, and that implemented here) behaves already
 2. only one test broke from having a relative path that was not explicitly relative