### PR TITLE
Bump go to 1.13.8 (and flatbuffers to 1.11.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - ./run-in-docker.sh make dep install test api-reference STATIC=yes
 
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.3
       before_install:
         # v8 prebuilt library
         - git clone https://github.com/jkcfg/prebuilt.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: minimal
 
 env:
   global:
-    - GOVERSION=1.12.1
+    - GOVERSION=1.13.8
     - GOMETALINTER_VERSION=2.0.11
     - GITHUB_RELEASE_VERSION=0.7.2
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install: jk
 	cp jk $(D)
 
 build-image:
-	docker build -t quay.io/justkidding/build -f build/Dockerfile build/
+	docker build -t jkcfg/build -f build/Dockerfile build/
 
 # Pulls the std/node_modules directory
 std-install:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build v8
-FROM golang:1.12.1 as v8builder
+FROM golang:1.13.8 as v8builder
 RUN apt-get update && apt-get install -y \
     bzip2 \
     libglib2.0-dev \
@@ -11,11 +11,11 @@ RUN cd $GOPATH/src/github.com/jkcfg/v8worker2 \
     && ./build.py
 
 # Build flatbuffer compiler, flatc
-FROM golang:1.12.1 as flatc-builder
+FROM golang:1.13.8 as flatc-builder
 RUN apt-get update && apt-get install -y \
     cmake \
   && rm -rf /var/lib/apt/lists/*
-ENV FLATBUFFERS_VERSION 1.10.0
+ENV FLATBUFFERS_VERSION 1.11.0
 RUN curl -fsSLO --compressed "https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz" \
     && tar -xf v${FLATBUFFERS_VERSION}.tar.gz \
     && rm v${FLATBUFFERS_VERSION}.tar.gz \
@@ -27,12 +27,12 @@ RUN curl -fsSLO --compressed "https://github.com/google/flatbuffers/archive/v${F
     && rm -rf flatbuffers-${FLATBUFFERS_VERSION}
 
 # Build github-release
-FROM golang:1.12.1 as github-release-builder
+FROM golang:1.13.8 as github-release-builder
 RUN go get github.com/aktau/github-release \
   && cp `go env GOPATH`/bin/github-release /usr/local/bin \
   && rm -rf `go env GOPATH`/src/github.com/aktau/github-release
 
-FROM golang:1.12.1 as fetcher
+FROM golang:1.13.8 as fetcher
 RUN apt-get update && apt-get install -y \
     xz-utils \
   && rm -rf /var/lib/apt/lists/*
@@ -56,7 +56,7 @@ RUN curl -fsSLo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/dow
     && chmod +x /usr/local/bin/gosu
 
 # Our final build image
-FROM golang:1.12.1
+FROM golang:1.13.8
 COPY --from=v8builder /go/src/github.com/jkcfg/v8worker2/v8.pc /usr/local/lib/pkgconfig/
 RUN sed -i \
      -e 's#Cflags: .*#Cflags: -I/usr/local/include/v8#' \

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/jkcfg/jk
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/google/flatbuffers v1.10.0
+	github.com/google/flatbuffers v1.11.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jkcfg/v8worker2 v0.0.0-20191022163158-90e467066938

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/google/flatbuffers v1.10.0 h1:wHCM5N1xsJ3VwePcIpVqnmjAqRXlR44gv4hpGi+/LIw=
-github.com/google/flatbuffers v1.10.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v1.11.0 h1:O7CEyB8Cb3/DmtxODGtLHcEvpr81Jm5qLg/hsHnxA2A=
+github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -224,7 +224,7 @@ func (std *Std) Execute(msg []byte, res sender) []byte {
 			}
 		}
 
-		if args.Sync() == 1 {
+		if args.Sync() {
 			result, err := rpcfn(arguments)
 			if err != nil {
 				return rpcError(err.Error())

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pkg=github.com/jkcfg/jk
-docker run -v "$(pwd)":/go/src/$pkg quay.io/justkidding/build "$@"
+docker run -v "$(pwd)":/go/src/$pkg jkcfg/build "$@"


### PR DESCRIPTION
Just to keep these modern.

There's one change to actual code needed: flatbuffers now returns a `bool` from getters for boolean fields, rather than a byte.

~NB: this needs an update to the prebuilt image, for the MacOSX build to succeed.~ EDIT: I've updated the prebuilt images. Now it complains that the MacOS version is too new -- https://travis-ci.org/jkcfg/jk/jobs/650639395#L169. I'm not sure what it's linking there; the only thing that got replaced is the `flatc` binary. TravisCI doesn't have an image for XCode from 10.15 :-/
