### PR TITLE
Ask TravisCI to cache the npm modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,17 @@ matrix:
     - os: linux
       services:
         - docker
+      cache:
+        directories:
+        - "$HOME/.npm" # npm ci will remove node_modules; this is _its_ download cache
       script:
         - ./run-in-docker.sh make dep install test api-reference STATIC=yes
 
     - os: osx
       osx_image: xcode11.3
+      cache:
+        directories:
+        - "$HOME/.npm"  # npm ci will remove node_modules; this is _its_ download cache
       before_install:
         # v8 prebuilt library
         - git clone https://github.com/jkcfg/prebuilt.git

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pkg=github.com/jkcfg/jk
-docker run -v "$(pwd)":/go/src/$pkg jkcfg/build "$@"
+docker run -v "$HOME/.npm":/go/src/$pkg/.npm -v "$(pwd)":/go/src/$pkg jkcfg/build "$@"


### PR DESCRIPTION
This commit adds directives to the TravicCI config so that it will
cache npm packages (kept in $HOME/.npm when using `npm ci`).

The directory so cached is mounted into the build container, so that
if the host has cached .npm packages, so will the container.