### PR TITLE
Switch release script to jkcfg/build

### DIFF
--- a/run-release.sh
+++ b/run-release.sh
@@ -9,7 +9,7 @@ repo=jk
 pkg=github.com/$user/$repo
 
 function docker_run() {
-    docker run -e GITHUB_TOKEN -e NPM_TOKEN -v "$(pwd)":/go/src/$pkg quay.io/justkidding/build "$@"
+    docker run -e GITHUB_TOKEN -e NPM_TOKEN -v "$(pwd)":/go/src/$pkg jkcfg/build "$@"
 }
 
 function run() {


### PR DESCRIPTION
In recent changes #320, I migrated the build image to `jkcfg/build` from `quay.io/justkidding/build`. This follows that change through to the image used in the release script, which I missed at the time.