### PR TITLE
Take more care with fs#walk

### DIFF
--- a/std/fs.ts
+++ b/std/fs.ts
@@ -63,41 +63,58 @@ export function join(base: string, name: string): string {
 const always = (): boolean => true;
 const noop = (): void => {};
 
-interface WalkOpts {
+export interface WalkOpts {
   pre?: (f: FileInfo) => boolean;
   post?: () => void;
 }
 
+/* eslint-disable no-labels */
+
+/** walk is a generator function that yields the files and directories
+ * under a given path, in a preorder traversal. "Preorder" means that
+ * the traversal is depth-first, and a directory is yielded
+ * immediately before the traversal examines its contents.
+ *
+ * @param path the starting point for the traversal, which should be a
+ * directory.
+ *
+ * @param opts pre- and post-hooks for the walk. The pre-hook is
+ * called for each directory after it is yielded; if it returns a
+ * falsey value, the directory is not traversed. The post-hook is
+ * called after a directory's contents have all been traversed. The
+ * starting point does not get treated as part of the traversal, i.e.,
+ * it starts with the contents of the directory at `path`.
+*/
 export function* walk(path: string, opts: WalkOpts = {}): IterableIterator<FileInfo> {
   const { pre = always, post = noop } = opts;
   const top = dir(path);
   // the stack is going to keep lists of files to examine
   const stack: FileInfo[][] = [];
   let next = top.files;
-  while (next !== undefined) {
+
+  // eslint-disable-next-line no-restricted-syntax
+  runNext: while (next !== undefined) {
     let i = 0;
     for (; i < next.length; i += 1) {
       const f = next[i];
+      yield f;
       if (f.isdir && pre(f)) {
         const d = dir(f.path);
         // If we need to recurse into the subdirectory, push the work
-        // yet to do here, then the subdirectory's files. If not, we
-        // can just continue as before.
+        // yet to do here, then process the subdirectory's files.
         if (d.files.length > 0) {
           stack.push(next.slice(i + 1));
-          stack.push(d.files);
-          yield f;
-          break;
-        } else {
-          yield f;
-          post();
-          continue;
+          next = d.files;
+          continue runNext;
         }
+        // If not, we can just continue through the current directory.
+        post();
       }
-      yield f;
     }
     // If we've exhausted the slice, we're popping a directory
-    if (i === next.length) post();
+    if (i === next.length && stack.length > 0) post();
     next = stack.pop();
   }
 }
+
+/* eslint-enable */

--- a/tests/test-fs-walk-post.js
+++ b/tests/test-fs-walk-post.js
@@ -1,11 +1,13 @@
 import { walk } from '@jkcfg/std/fs';
 import { print } from '@jkcfg/std';
 
-// walk should call post for every time it finishes a directory.
+// walk should call post for every time it finishes a directory. to
+// check that the hook is called at the right time, include it in the
+// transcript.
 
-const nested = [];
-for (const f of walk('./fs-walk-preorder-files', { pre: v => nested.push(v.name), post: () => nested.pop() })) {
+const post = () => print('post');
+const pre = f => print(`pre ${f.name}`) || true;
+
+for (const f of walk('./fs-walk-preorder-files', { pre, post })) {
   if (!f.name.startsWith('.')) print(f.name);
 }
-
-if (nested.length > 0) throw new Error(`did not pop as many directories as pushed, left with ${nested.join(', ')}`);

--- a/tests/test-fs-walk-post.js.expected
+++ b/tests/test-fs-walk-post.js.expected
@@ -1,9 +1,19 @@
 A
+pre A
 B
+pre B
 C
 D
+post
 E
+pre E
+post
 F
+pre F
 G
 H
+pre H
 I
+post
+post
+post

--- a/tests/test-fs-walk-preorder.js
+++ b/tests/test-fs-walk-preorder.js
@@ -4,6 +4,18 @@ import { print } from '@jkcfg/std';
 // The files and directories in fs-walk-preorder-files are designed to
 // be in alphabetical order, when traversed in preorder.
 
-for (const f of walk('./fs-walk-preorder-files')) {
+// To check the pre hook is called _immediately after_ we've seen a
+// directory, this is set for every file, and verified in the
+// pre-hook.
+let lastname = '';
+const pre = (f) => {
+  if (lastname !== f.name) {
+    throw new Error(`expected to see '${lastname}' in pre-hook, saw '${f.name}'`);
+  }
+  return true;
+};
+
+for (const f of walk('./fs-walk-preorder-files', { pre })) {
+  lastname = f.name;
   if (!f.name.startsWith('.')) print(f.name);
 }


### PR DESCRIPTION
There were a couple of problems with the implementation:

 - the pre hook was called before yielding a directory. This isn't
   wrong so much as inconvenient -- you can't indent on pre-, and
   outdent on post-, for example.

 - the post hook was called at the top of the stack, i.e., when
   leaving the starting point, so everything had some variety of
   off-by-one problem.

This commits makes the tests a bit more rigorous (the post-hook test
in particular didn't check that the number of times leaving a
directory was equal to the number of times entering a
directory!). I've also given the walk procedure some typedocs, so it
has a better explanation in the API reference.