### PR TITLE
Make print, Format, Encoding available to -c

### DIFF
--- a/run.go
+++ b/run.go
@@ -47,7 +47,7 @@ func runExamples() string {
 }
 
 const inlineTemplate = `
-import { log, write, read } from '@jkcfg/std';
+import { print, log, write, read, Format, Encoding } from '@jkcfg/std';
 import { dir, info } from '@jkcfg/std/fs';
 import * as param from '@jkcfg/std/param';
 


### PR DESCRIPTION
It's not only useful to be able to print values, but also to print
them in a particular format; likewise, reading in a particular
encoding.

This addresses #191, though not as requested there :-)