### PR TITLE
Validate and transform multi-values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0
 	golang.org/x/text v0.3.0
-	golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a // indirect
+	golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a
 	gopkg.in/yaml.v2 v2.2.1
 )
 

--- a/std/cmd/generate.ts
+++ b/std/cmd/generate.ts
@@ -173,36 +173,24 @@ function assembleForStdout(values: RealisedFile[]) {
 
     switch (format) {
     case std.Format.YAML:
-      if (stdoutFormat !== undefined && stdoutFormat !== std.Format.YAMLStream) {
-        error(`stdout requires compatible formats, but have seen ${usedFormats(formatsSeen).join(',')}`);
-        return { valid: false }
-      }
-      stdoutFormat = std.Format.YAMLStream;
-      stream.push(v.value);
-      break;
     case std.Format.YAMLStream:
       if (stdoutFormat !== undefined && stdoutFormat !== std.Format.YAMLStream) {
         error(`stdout requires compatible formats, but have seen ${usedFormats(formatsSeen).join(',')}`);
         return { valid: false }
       }
       stdoutFormat = std.Format.YAMLStream;
-      stream = stream.concat(v.value);
+      stream = (format === std.Format.YAML) ?
+        stream.push(v.value) && stream : stream.concat(v.value);
       break;
     case std.Format.JSON:
-      if (stdoutFormat !== undefined && stdoutFormat !== std.Format.JSONStream) {
-        error(`stdout requires compatible formats, but have seen ${usedFormats(formatsSeen).join(',')}`);
-        return { valid: false }
-      }
-      stdoutFormat = std.Format.JSONStream;
-      stream.push(v.value);
-      break;
     case std.Format.JSONStream:
       if (stdoutFormat !== undefined && stdoutFormat !== std.Format.JSONStream) {
         error(`stdout requires compatible formats, but have seen ${usedFormats(formatsSeen).join(',')}`);
         return { valid: false }
       }
       stdoutFormat = std.Format.JSONStream;
-      stream = stream.concat(v.value);
+      stream = (format === std.Format.JSON) ?
+        stream.push(v.value) && stream : stream.concat(v.value);
       break;
     default:
       // for anything else, only one value is allowed; therefore keep

--- a/std/cmd/transform.ts
+++ b/std/cmd/transform.ts
@@ -1,6 +1,7 @@
 import * as std from '../index';
 import * as param from '../param';
 import { generate, File, GenerateParams } from './generate';
+import { valuesFormatFromPath } from '../read';
 
 type TransformFn = (value: any) => any | void;
 
@@ -8,19 +9,6 @@ const inputParams: GenerateParams = {
   stdout: param.Boolean('jk.transform.stdout', false),
   overwrite: param.Boolean('jk.transform.overwrite', false) ? std.Overwrite.Write : std.Overwrite.Err,
 };
-
-function readFormatFromPath(path: string): std.Format {
-  const ext = path.split('.').pop();
-  switch (ext) {
-  case 'yaml':
-  case 'yml':
-    return std.Format.YAMLStream;
-  case 'json':
-    return std.Format.JSONStream;
-  default:
-    return std.Format.FromExtension;
-  }
-}
 
 function transformOne(fn: TransformFn, file: string, obj: any): File {
   let txObj = fn(obj);
@@ -35,7 +23,7 @@ function transform(fn: TransformFn): void {
   const inputFiles = param.Object('jk.transform.input', {});
   const outputs = [];
   for (const file of Object.keys(inputFiles)) {
-    const format = readFormatFromPath(file);
+    const format = valuesFormatFromPath(file);
     outputs.push(std.read(file, { format }).then((obj): File[] => {
       switch (format) {
       case std.Format.YAMLStream:

--- a/std/cmd/validate.ts
+++ b/std/cmd/validate.ts
@@ -1,6 +1,7 @@
 import * as std from '../index';
 import * as param from '../param';
 import { formatError, normaliseResult, ValidationError, ValidationResult, ValidateFnResult } from '../validation';
+import { valuesFormatFromPath } from '../read';
 
 export type ValidateFn = (obj: any) => ValidateFnResult | Promise<ValidateFnResult>;
 
@@ -9,15 +10,36 @@ interface FileResult {
   result: ValidationResult;
 }
 
+function reduce(results: ValidationResult[]): ValidationResult {
+  return results.reduce((a: ValidationResult, b: ValidationResult): ValidationResult => {
+    if (a == 'ok') return b;
+    if (b == 'ok') return a;
+    return Array.prototype.concat(a, b);
+  }, 'ok');
+}
+
 export default function validate(fn: ValidateFn): void {
   const inputFiles = param.Object('jk.validate.input', {});
   const files = Object.keys(inputFiles);
 
-  const validateFile = async function vf(path: string): Promise<FileResult> {
-    const obj = await std.read(path);
-    const result = normaliseResult(await Promise.resolve(fn(obj)));
-    return { path, result };
-  };
+  function validateValue(v: any): Promise<ValidationResult> {
+    return Promise.resolve(fn(v)).then(normaliseResult);
+  }
+
+  async function validateFile(path: string): Promise<FileResult> {
+    const format = valuesFormatFromPath(path);
+    const obj = await std.read(path, { format });
+    switch (format) {
+    case std.Format.YAMLStream:
+    case std.Format.JSONStream:
+      const results: Promise<ValidationResult>[] = obj.map(validateValue);
+      const resolvedResults = await Promise.all(results);
+      return { path, result: reduce(resolvedResults) };
+    default:
+      const result = await validateValue(obj);
+      return { path, result };
+    }
+  }
 
   const objects = files.map(validateFile);
   Promise.all(objects).then((results): void => {

--- a/std/read.ts
+++ b/std/read.ts
@@ -27,6 +27,24 @@ export interface ReadOptions {
   module?: string;
 }
 
+// valuesFormatFromPath guesses, for a path, the format that will
+// return all values in a file. In other words, it prefers YAML
+// streams and concatenated JSON. You may need to treat the read value
+// differently depending on the format you got here, since YAMLStream
+// and JSONStream will both result in an array of values.
+export function valuesFormatFromPath(path: string): Format {
+  const ext = path.split('.').pop();
+  switch (ext) {
+  case 'yaml':
+  case 'yml':
+    return Format.YAMLStream;
+  case 'json':
+    return Format.JSONStream;
+  default:
+    return Format.FromExtension;
+  }
+}
+
 // read requests the path and returns a promise that will be resolved
 // with the contents at the path, or rejected.
 export function read(path: string, opts: ReadOptions = {}): Promise<any> {

--- a/tests/test-transform-multidoc-file.expected/test-transform-files/numbers.yaml
+++ b/tests/test-transform-multidoc-file.expected/test-transform-files/numbers.yaml
@@ -1,0 +1,3 @@
+plusone: 2
+---
+plusone: 3

--- a/tests/test-transform-multidoc-file.js.cmd
+++ b/tests/test-transform-multidoc-file.js.cmd
@@ -1,0 +1,2 @@
+rm -rf ./%d/test-transform-files
+jk transform -c '({ number }) => ({ plusone: number + 1 })' ./test-transform-files/numbers.yaml -o %d

--- a/tests/test-validate-multifile.js.cmd
+++ b/tests/test-validate-multifile.js.cmd
@@ -1,0 +1,1 @@
+jk validate -m ./validate-files/module ./testfiles/validate/validate-multi.yaml

--- a/tests/test-validate-multifile.js.expected
+++ b/tests/test-validate-multifile.js.expected
@@ -1,0 +1,1 @@
+./testfiles/validate/validate-multi.yaml: object name is not "Valid"

--- a/tests/testfiles/validate/validate-multi.yaml
+++ b/tests/testfiles/validate/validate-multi.yaml
@@ -1,0 +1,10 @@
+---
+# The first value is valid; if no other values are read, the result will
+# be 'ok'
+name: Valid
+other: stuff
+---
+# The second value is invalid; if this one is read as well, the result
+# will be an error.
+version: 3
+name: Invalid


### PR DESCRIPTION
Fixes #332 (transform should write a multidoc input to multidoc file) and #333 (validate needs to treat all files that could contain multiple values as having multiple values, and validate all of those values).
