### PR TITLE
Provide TypeScript definitions for std/resource

### DIFF
--- a/std/resource.d.ts
+++ b/std/resource.d.ts
@@ -1,0 +1,37 @@
+/**
+ * @module std/resource
+ */
+
+// This contains definitions for @jkcfg/std/resource, which is
+// normally supplied by the runtime.
+
+import { ReadOptions } from './read';
+import {
+  InfoOptions,
+  DirOptions,
+  FileInfo,
+  Directory,
+} from './fs';
+
+/**
+ * read shall read the contents of the file at the path given,
+ * relative to the importing module.
+ */
+export declare function read(path: string, opts?: ReadOptions): Promise<any>;
+
+/**
+ * info shall give the file info at the path given, relative to the
+ * importing module.
+ */
+export declare function info(path: string, options: InfoOptions): FileInfo;
+
+/**
+ * dir shall give the directory info at the path given, relative to
+ * the importing module.
+ */
+export declare function dir(path: string, options: DirOptions): Directory;
+
+/**
+ * @ignore
+ */
+export declare function withModuleRef(fn: (ref: string) => any): any;

--- a/std/tsconfig.json
+++ b/std/tsconfig.json
@@ -18,6 +18,7 @@
   "typedocOptions": {
     "out": "docs",
     "mode": "modules",
+    "includeDeclarations": true,
     "excludeNotExported": true,
     "excludeExternals": true,
     "externalPattern": [
@@ -25,6 +26,8 @@
       "cmd/**/*.{ts,js}",
       "docs/**/*.{ts,js}",
       "dist/**/*.{ts.js}",
+      "debug.ts",
+      "v8worker.d.ts",
       "index.ts"
     ],
     "hideGenerator": true,


### PR DESCRIPTION
This helps with writing TypeScript with jk, and it also means we can
get some typedoc happening for the resource module.

_En passant_, I've set typedoc to ignore debug.js, which is for
debugging RPC, and v8worker.d.ts, which are internal and don't need
inclusion in the docs.

Fixes #263.