### PR TITLE
Make files mentioned on the command line readable, even with parent paths

### DIFF
--- a/pkg/resolve/magic_importer.go
+++ b/pkg/resolve/magic_importer.go
@@ -9,11 +9,15 @@ import (
 type MagicImporter struct {
 	Specifier string
 	Generate  func(vfs.Location) ([]byte, string)
+	Public    bool // can this be imported from any module?
 }
 
 // Import implements the Importer interface for MagicImporter.
 func (m *MagicImporter) Import(base vfs.Location, specifier, referrer string) ([]byte, vfs.Location, []Candidate) {
 	if m.Specifier == specifier {
+		if !m.Public && !IsStdModule(referrer) {
+			return nil, vfs.Nowhere, nil
+		}
 		source, p := m.Generate(base)
 		return source, vfs.Location{Vfs: vfs.Empty, Path: p}, nil
 	}

--- a/pkg/resolve/magic_importer_test.go
+++ b/pkg/resolve/magic_importer_test.go
@@ -1,0 +1,49 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jkcfg/jk/pkg/vfs"
+)
+
+func TestMagicImporter(t *testing.T) {
+	spec := "@jkcfg/magic"
+	mod := []byte("export default foo = 1;")
+	importer := MagicImporter{
+		Specifier: spec,
+		Generate: func(vfs.Location) ([]byte, string) {
+			return mod, "foo.js"
+		},
+	}
+
+	// Get the module if you 1. ask for the right thing and 2. are a std module yourself
+	bytes, _, candidates := importer.Import(ScriptBase("."), spec, "@jkcfg/std/other")
+	assert.Equal(t, mod, bytes)
+	assert.Nil(t, candidates)
+
+	var loc vfs.Location
+	// Doesn't respond to anything that is not the magic module
+	bytes, loc, _ = importer.Import(ScriptBase("."), "@jkcfg/notmagic", "@jkcfg/std/other")
+	assert.Equal(t, vfs.Nowhere, loc)
+	assert.Nil(t, bytes)
+
+	// Doesn't respond if the referrer is not in std
+	bytes, loc, _ = importer.Import(ScriptBase("."), spec, "rando.js")
+	assert.Equal(t, vfs.Nowhere, loc)
+	assert.Nil(t, bytes)
+
+	// Make it public; should be accessible from modules outside std
+	importer = MagicImporter{
+		Specifier: spec,
+		Generate: func(vfs.Location) ([]byte, string) {
+			return mod, "foo.js"
+		},
+		Public: true,
+	}
+
+	bytes, _, candidates = importer.Import(ScriptBase("."), spec, "rando.js")
+	assert.Equal(t, mod, bytes)
+	assert.Nil(t, candidates)
+}

--- a/pkg/resolve/std_importer.go
+++ b/pkg/resolve/std_importer.go
@@ -18,7 +18,10 @@ type StdImporter struct {
 	PublicModules []string
 }
 
-func isStdModule(name string) bool {
+// IsStdModule returns `true` if the module name given is part of the
+// standard library, false otherwise. Useful for checking the referrer
+// (importing module), to restrict access to internals.
+func IsStdModule(name string) bool {
 	return strings.HasPrefix(name, stdPrefix)
 }
 
@@ -39,12 +42,12 @@ func (i *StdImporter) Import(base vfs.Location, specifier, referrer string) ([]b
 	// @jkcfg/std.* module. `Relative` should take care of loading
 	// imports on relative paths when the importing module is also a
 	// std module.
-	if !isStdModule(specifier) {
+	if !IsStdModule(specifier) {
 		return nil, vfs.Nowhere, candidate
 	}
 
 	p := specifier
-	if isStdModule(p) {
+	if IsStdModule(p) {
 		p = specifier[len(stdPrefix):]
 	}
 	p = strings.TrimPrefix(p, "/")
@@ -59,7 +62,7 @@ func (i *StdImporter) Import(base vfs.Location, specifier, referrer string) ([]b
 	// from the std lib itself are allowed to import internal private
 	// modules.
 	m := i.publicModule(p)
-	if !isStdModule(referrer) && m == "" {
+	if !IsStdModule(referrer) && m == "" {
 		trace(i, "'%s' is not a public module", specifier)
 		return nil, vfs.Nowhere, candidate
 	}

--- a/pkg/std/fs.go
+++ b/pkg/std/fs.go
@@ -28,42 +28,39 @@ type Directory struct {
 // MakeFileInfo returns a response to a FileInfo request, encoded
 // ready to send to the V8 worker.
 func MakeFileInfo(r ReadBase, path, module string) (FileInfo, error) {
-	loc, rel, err := r.getPath(path, module)
+	loc, err := r.getPath(path, module)
 	if err != nil {
 		return FileInfo{}, err
 	}
-	return fileInfo(loc, rel)
+	return fileInfo(loc, path)
 }
 
 // MakeDirectoryListing returns a response to a Dir request, encoded
 // ready to send to the V8 worker.
-func MakeDirectoryListing(r ReadBase, path, module string) (Directory, error) {
-	loc, rel, err := r.getPath(path, module)
+func MakeDirectoryListing(r ReadBase, p, module string) (Directory, error) {
+	loc, err := r.getPath(p, module)
 	if err != nil {
 		return Directory{}, err
 	}
-	return directoryListing(loc, rel)
+	return directoryListing(loc, p)
 }
 
-func fileInfo(loc vfs.Location, rel string) (FileInfo, error) {
-	p := path.Join(loc.Path, rel)
-	info, err := vfsutil.Stat(loc.Vfs, p)
+func fileInfo(loc vfs.Location, p string) (FileInfo, error) {
+	info, err := vfsutil.Stat(loc.Vfs, loc.Path)
 	switch {
 	case err != nil:
 		return FileInfo{}, err
 	case !(info.IsDir() || info.Mode().IsRegular()):
 		return FileInfo{}, errors.New("not a regular file")
 	}
-	return FileInfo{Name: info.Name(), Path: rel, IsDir: info.IsDir()}, nil
+	return FileInfo{Name: info.Name(), Path: p, IsDir: info.IsDir()}, nil
 }
 
-func directoryListing(base vfs.Location, rel string) (Directory, error) {
-	p := path.Join(base.Path, rel)
-	dir, err := base.Vfs.Open(p)
+func directoryListing(loc vfs.Location, p string) (Directory, error) {
+	dir, err := loc.Vfs.Open(loc.Path)
 	if err != nil {
 		return Directory{}, err
 	}
-	defer dir.Close()
 	infos, err := dir.Readdir(0)
 	if err != nil {
 		return Directory{}, err
@@ -80,15 +77,15 @@ func directoryListing(base vfs.Location, rel string) (Directory, error) {
 		if infos[i].IsDir() || infos[i].Mode().IsRegular() {
 			files = append(files, FileInfo{
 				Name:  infos[i].Name(),
-				Path:  path.Join(rel, infos[i].Name()),
+				Path:  path.Join(p, infos[i].Name()),
 				IsDir: infos[i].IsDir(),
 			})
 		}
 	}
 
 	return Directory{
-		Name:  path.Base(rel),
-		Path:  rel,
+		Name:  path.Base(p),
+		Path:  p,
 		Files: files,
 	}, nil
 }

--- a/pkg/std/fs.go
+++ b/pkg/std/fs.go
@@ -25,9 +25,9 @@ type Directory struct {
 	Files []FileInfo `json:"files"`
 }
 
-// FileInfo returns a response to a FileInfo request, encoded ready to
-// send to the V8 worker.
-func (r ReadBase) FileInfo(path, module string) (FileInfo, error) {
+// MakeFileInfo returns a response to a FileInfo request, encoded
+// ready to send to the V8 worker.
+func MakeFileInfo(r ReadBase, path, module string) (FileInfo, error) {
 	loc, rel, err := r.getPath(path, module)
 	if err != nil {
 		return FileInfo{}, err
@@ -35,9 +35,9 @@ func (r ReadBase) FileInfo(path, module string) (FileInfo, error) {
 	return fileInfo(loc, rel)
 }
 
-// DirectoryListing returns a response to a Dir request, encoded ready
-// to send to the V8 worker.
-func (r ReadBase) DirectoryListing(path, module string) (Directory, error) {
+// MakeDirectoryListing returns a response to a Dir request, encoded
+// ready to send to the V8 worker.
+func MakeDirectoryListing(r ReadBase, path, module string) (Directory, error) {
 	loc, rel, err := r.getPath(path, module)
 	if err != nil {
 		return Directory{}, err

--- a/pkg/std/read.go
+++ b/pkg/std/read.go
@@ -107,17 +107,16 @@ func (r ReadBase) Read(relPath string, format __std.Format, encoding __std.Encod
 		return read(nil, "", format, encoding)
 	}
 
-	base, rel, err := r.getPath(relPath, module)
+	loc, err := r.getPath(relPath, module)
 	if err != nil {
 		return nil, err
 	}
-	fullpath := path.Join(base.Path, rel)
 	if r.Recorder != nil {
 		r.Recorder.Record(record.ReadFile, record.Params{
-			"path": base.Vfs.QualifyPath(fullpath),
+			"path": loc.Vfs.QualifyPath(loc.Path),
 		})
 	}
-	return read(base.Vfs, fullpath, format, encoding)
+	return read(loc.Vfs, loc.Path, format, encoding)
 }
 
 func read(vfs http.FileSystem, p string, format __std.Format, encoding __std.Encoding) ([]byte, error) {

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -174,11 +174,11 @@ func (std *Std) Execute(msg []byte, res sender) []byte {
 		switch method {
 		case "std.fileinfo":
 			rpcfn = requireTwoStrings(func(path, module string) (interface{}, error) {
-				return options.Root.FileInfo(path, module)
+				return MakeFileInfo(options.Root, path, module)
 			})
 		case "std.dir":
 			rpcfn = requireTwoStrings(func(path, module string) (interface{}, error) {
-				return options.Root.DirectoryListing(path, module)
+				return MakeDirectoryListing(options.Root, path, module)
 			})
 		case "std.validate.schema":
 			rpcfn = requireTwoStrings(func(v, s string) (interface{}, error) {

--- a/pkg/std/std.go
+++ b/pkg/std/std.go
@@ -186,11 +186,11 @@ func (std *Std) Execute(msg []byte, res sender) []byte {
 			})
 		case "std.validate.schemafile":
 			rpcfn = requireThreeStrings(func(v, path, moduleRef string) (interface{}, error) {
-				base, rel, err := options.Root.getPath(path, moduleRef)
+				loc, err := options.Root.getPath(path, moduleRef)
 				if err != nil {
 					return nil, err
 				}
-				return schema.ValidateWithFile(v, base.Vfs, filepath.Join(base.Path, rel))
+				return schema.ValidateWithFile(v, loc.Vfs, loc.Path)
 			})
 		default:
 			rpcfn = options.ExtMethods[method]

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -80,8 +80,9 @@ func Internal(prefix string, fs http.FileSystem) InternalFileSystem {
 
 // Location is a path within a specific filesystem.
 type Location struct {
-	Vfs  FileSystem
-	Path string
+	Vfs              FileSystem
+	Path             string
+	AllowParentPaths bool
 }
 
 // CanonicalPath gives an identifying (though not necessarily valid) path

--- a/std/cmd/transform.ts
+++ b/std/cmd/transform.ts
@@ -1,4 +1,5 @@
-import * as std from '../index';
+import { Format, Overwrite } from '../index';
+import * as host from '@jkcfg/std/internal/host'; // magic module
 import * as param from '../param';
 import { generate, File, GenerateParams } from './generate';
 import { valuesFormatFromPath } from '../read';
@@ -7,7 +8,7 @@ type TransformFn = (value: any) => any | void;
 
 const inputParams: GenerateParams = {
   stdout: param.Boolean('jk.transform.stdout', false),
-  overwrite: param.Boolean('jk.transform.overwrite', false) ? std.Overwrite.Write : std.Overwrite.Err,
+  overwrite: param.Boolean('jk.transform.overwrite', false) ? Overwrite.Write : Overwrite.Err,
 };
 
 function transform(fn: TransformFn): void {
@@ -22,10 +23,10 @@ function transform(fn: TransformFn): void {
   const outputs = [];
   for (const path of Object.keys(inputFiles)) {
     const format = valuesFormatFromPath(path);
-    outputs.push(std.read(path, { format }).then((obj): File => {
+    outputs.push(host.read(path, { format }).then((obj): File => {
       switch (format) {
-      case std.Format.YAMLStream:
-      case std.Format.JSONStream:
+      case Format.YAMLStream:
+      case Format.JSONStream:
         return {
           path,
           format,

--- a/std/cmd/validate.ts
+++ b/std/cmd/validate.ts
@@ -1,4 +1,5 @@
-import * as std from '../index';
+import { log, Format } from '../index';
+import * as host from '@jkcfg/std/internal/host'; // magic module
 import * as param from '../param';
 import { formatError, normaliseResult, ValidationError, ValidationResult, ValidateFnResult } from '../validation';
 import { valuesFormatFromPath } from '../read';
@@ -28,10 +29,10 @@ export default function validate(fn: ValidateFn): void {
 
   async function validateFile(path: string): Promise<FileResult> {
     const format = valuesFormatFromPath(path);
-    const obj = await std.read(path, { format });
+    const obj = await host.read(path, { format });
     switch (format) {
-    case std.Format.YAMLStream:
-    case std.Format.JSONStream:
+    case Format.YAMLStream:
+    case Format.JSONStream:
       const results: Promise<ValidationResult>[] = obj.map(validateValue);
       const resolvedResults = await Promise.all(results);
       return { path, result: reduce(resolvedResults) };
@@ -45,10 +46,10 @@ export default function validate(fn: ValidateFn): void {
   Promise.all(objects).then((results): void => {
     for (const { path, result } of results) {
       if (result === 'ok') {
-        std.log(`${path}: ok`);
+        log(`${path}: ok`);
       } else {
         for (const err of result) {
-          std.log(formatError(path, err));
+          log(formatError(path, err));
         }
       }
     }

--- a/std/internal/host.d.ts
+++ b/std/internal/host.d.ts
@@ -1,0 +1,33 @@
+// This contains definitions for @jkcfg/std/internal/host, which is
+// normally supplied by the runtime.
+
+import { ReadOptions } from '../read';
+import {
+  InfoOptions,
+  DirOptions,
+  FileInfo,
+  Directory,
+} from '../fs';
+
+/**
+ * read shall read the contents of the file at the path given,
+ * relative to the importing module.
+ */
+export declare function read(path: string, opts?: ReadOptions): Promise<any>;
+
+/**
+ * info shall give the file info at the path given, relative to the
+ * importing module.
+ */
+export declare function info(path: string, options: InfoOptions): FileInfo;
+
+/**
+ * dir shall give the directory info at the path given, relative to
+ * the importing module.
+ */
+export declare function dir(path: string, options: DirOptions): Directory;
+
+/**
+ * @ignore
+ */
+export declare function withModuleRef(fn: (ref: string) => any): any;

--- a/std/tsconfig.json
+++ b/std/tsconfig.json
@@ -13,7 +13,11 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "baseUrl": ".",
+    "paths": {
+      "@jkcfg/std/*": ["./*"]
+    }
   },
   "typedocOptions": {
     "out": "docs",

--- a/vm.go
+++ b/vm.go
@@ -182,7 +182,7 @@ func (vm *vm) setWorkingDirectory(dir string) {
 
 func (vm *vm) resolver() *resolve.Resolver {
 	hostFs := vfs.User("file://", http.Dir("/"))
-	workingDir := vfs.Location{Vfs: hostFs, Path: vm.inputDir}
+	workingDir := vfs.Location{Vfs: hostFs, Path: vm.inputDir, AllowParentPaths: true}
 	hostModule, hostModulePath := vm.resources.MakeModule(workingDir)
 	makeHostModule := func(_ vfs.Location) ([]byte, string) {
 		return hostModule, hostModulePath

--- a/vm.go
+++ b/vm.go
@@ -170,11 +170,12 @@ func (vm *vm) setWorkingDirectory(dir string) {
 
 	inputDir := dir
 	if vm.inputDirectory != "" {
-		var err error
-		inputDir, err = filepath.Abs(vm.inputDirectory)
-		if err != nil {
-			log.Fatal(err)
-		}
+		inputDir = vm.inputDirectory
+	}
+
+	inputDir, err = filepath.Abs(inputDir)
+	if err != nil {
+		log.Fatal(err)
 	}
 	vm.inputDir = inputDir
 }

--- a/vm.go
+++ b/vm.go
@@ -180,10 +180,22 @@ func (vm *vm) setWorkingDirectory(dir string) {
 }
 
 func (vm *vm) resolver() *resolve.Resolver {
+	hostFs := vfs.User("file://", http.Dir("/"))
+	workingDir := vfs.Location{Vfs: hostFs, Path: vm.inputDir}
+	hostModule, hostModulePath := vm.resources.MakeModule(workingDir)
+	makeHostModule := func(_ vfs.Location) ([]byte, string) {
+		return hostModule, hostModulePath
+	}
+
 	resolver := resolve.NewResolver(vm.worker,
 		resolve.ScriptBase(vm.scriptDir),
 		&resolve.Relative{},
-		&resolve.MagicImporter{Specifier: "@jkcfg/std/resource", Generate: vm.resources.MakeModule},
+		&resolve.MagicImporter{
+			Specifier: "@jkcfg/std/resource",
+			Generate:  vm.resources.MakeModule,
+			Public:    true,
+		},
+		&resolve.MagicImporter{Specifier: "@jkcfg/std/internal/host", Generate: makeHostModule},
 		&resolve.StdImporter{
 			// List here the modules users are allowed to access.
 			PublicModules: []string{"index.js", "param.js", "fs.js", "merge.js", "debug.js", "schema.js"},


### PR DESCRIPTION
Usually jk would forbid reading outside the input directory, but in the case of `jk transform` and `jk validate`, the files to process are given on the command line. It is a standing oddity that these commands invite arbitrary file paths, but can't actually process those outside the current directory.

This PR does a bit of rearranging, and uses the magic module facility, so that the `transform` and `validate` commands are able to read files from the real filesystem, even those with parent paths or absolute paths. This is the mechanism:

 - a magic module `@jkcfg/std/internal/host` is created when the VM is initialised, which is registered as having access to the whole filesystem (and not proscribing absolute or parent paths);
 - this module can only be imported from `@jkcfg/std/*`;
 - std/cmd/transform and std/cmd/validate import that module and use it to read the paths they are given on the command-line.

Fixes #293.