### PR TITLE
Use const symbols for stdin and stdout

### DIFF
--- a/std/cmd/generate.ts
+++ b/std/cmd/generate.ts
@@ -270,7 +270,7 @@ export function generate(definition: GenerateArg, params: GenerateParams) {
       if (!valid) {
         throw new Error('jk-internal-skip: validation failed');
       }
-      std.write(stream, '', { format: stdoutFormat });
+      std.write(stream, std.stdout, { format: stdoutFormat });
     } else {
       for (const o of files) {
         const { path, value, ...args } = o;

--- a/std/index.ts
+++ b/std/index.ts
@@ -1,9 +1,10 @@
 export { log } from './log';
 export {
+  stdout,
   Format,
   Overwrite,
   write,
   print,
 } from './write';
-export { Encoding, read } from './read';
+export { Encoding, read, stdin } from './read';
 export { parse, stringify } from './parse';

--- a/std/read.ts
+++ b/std/read.ts
@@ -13,6 +13,8 @@ import { flatbuffers } from './internal/flatbuffers';
 import { __std } from './internal/__std_generated';
 import { Format } from './write';
 
+export const stdin: unique symbol = Symbol('<stdin>');
+
 /* we re-define Encoding from the generated __std.Encoding to document it */
 
 export enum Encoding {
@@ -45,13 +47,16 @@ export function valuesFormatFromPath(path: string): Format {
   }
 }
 
+type ReadPath = string | typeof stdin;
+
 // read requests the path and returns a promise that will be resolved
 // with the contents at the path, or rejected.
-export function read(path: string, opts: ReadOptions = {}): Promise<any> {
+export function read(path: ReadPath = stdin, opts: ReadOptions = {}): Promise<any> {
   const { encoding = Encoding.JSON, format = Format.FromExtension, module } = opts;
+  const pathArg = (path === stdin) ? '' : path;
 
   const builder = new flatbuffers.Builder(512);
-  const pathOffset = builder.createString(path);
+  const pathOffset = builder.createString(pathArg);
   let moduleOffset = 0;
   if (module !== undefined) {
     moduleOffset = builder.createString(module);

--- a/tests/test-jsonstream.js
+++ b/tests/test-jsonstream.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 
 const value = std.read('./test-jsonstream.js.expected', { format: std.Format.JSONStream });
-value.then(v => std.write(v, '', { format: std.Format.JSONStream }));
+value.then(v => std.write(v, std.stdout, { format: std.Format.JSONStream }));

--- a/tests/test-params-issue-122.js
+++ b/tests/test-params-issue-122.js
@@ -2,4 +2,4 @@ import * as std from '@jkcfg/std';
 import * as param from '@jkcfg/std/param';
 
 const values = param.Object('values');
-std.write(values, '');
+std.write(values, std.stdout);

--- a/tests/test-std-ts/test.ts
+++ b/tests/test-std-ts/test.ts
@@ -1,6 +1,6 @@
 import * as std from '@jkcfg/std';
 
 std.log('success');
-std.write('success', '');
-std.write('success', '', { format: std.Format.JSON, indent: 2, overwrite: false });
+std.write('success', std.stdout);
+std.write('success', std.stdout, { format: std.Format.JSON, indent: 2, overwrite: false });
 std.read('success.json').then(json => std.log(json.message));

--- a/tests/test-stdin.js
+++ b/tests/test-stdin.js
@@ -1,4 +1,4 @@
 import * as std from '@jkcfg/std';
 
-std.read('', { format: std.Format.JSONStream })
-  .then(v => std.write(v, '', { format: std.Format.YAMLStream }));
+std.read(std.stdin, { format: std.Format.JSONStream })
+  .then(v => std.write(v, std.stdout, { format: std.Format.YAMLStream }));


### PR DESCRIPTION
Up to now, passing `''` has meant stdin (for read) and stdout (for
write), but this is not very guessable.

Instead, use a symbol for each of `stdin` and `stdout`. The
combo-keyword `unique symbol` in TypeScript means that `typeof stdin`
will accept only that symbol (in contrast with the type `symbol`).

This, along with changes to the docs in the website, should help with #161.