### PR TITLE
Use golangci-lint rather than gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: minimal
 env:
   global:
     - GOVERSION=1.13.8
-    - GOMETALINTER_VERSION=2.0.11
+    - GOLANGCI_LINT_VERSION=v1.24.0
     - GITHUB_RELEASE_VERSION=0.7.2
 
 matrix:
@@ -31,9 +31,8 @@ matrix:
         # go
         - (cd ~ && curl -fsSLO https://dl.google.com/go/go${GOVERSION}.darwin-amd64.tar.gz)
         - mkdir ~/go-${GOVERSION} && tar xf ~/go${GOVERSION}.darwin-amd64.tar.gz -C ~/go-${GOVERSION} --strip-components 1
-        # gometalinter
-        - (cd ~ && curl -fsSLO https://github.com/alecthomas/gometalinter/releases/download/v${GOMETALINTER_VERSION}/gometalinter-${GOMETALINTER_VERSION}-darwin-amd64.tar.gz)
-        - tar -xf ~/gometalinter-${GOMETALINTER_VERSION}-darwin-amd64.tar.gz -C /usr/local/bin --strip-components 1
+        # golangci-linter
+        - (cd ~ && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION})
         # github-release
         - (cd ~ && curl -fsSLO https://github.com/aktau/github-release/releases/download/v${GITHUB_RELEASE_VERSION}/darwin-amd64-github-release.tar.bz2)
         - tar -xf ~/darwin-amd64-github-release.tar.bz2 -C /usr/local/bin --strip-components 3

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -32,14 +32,15 @@ echo "==> Running eslint on examples"
 
 echo
 echo "==> Running go linters"
-gometalinter --tests --vendor --disable-all --deadline=600s \
-    --enable=misspell \
-    --enable=vet \
-    --enable=ineffassign \
-    --enable=gofmt \
-    --enable=deadcode \
-    --enable=golint \
-    ./...
+golangci-lint run --no-config --timeout=600s \
+  --disable-all --enable=deadcode --enable=golint --enable=varcheck \
+  --enable=structcheck --enable=dupl --enable=ineffassign \
+  --enable=interfacer --enable=govet --enable=gofmt --enable=misspell \
+  ./...
+
+# these are unused linters at present; some may fail.
+# --enable=unconvert --enable=megacheck --enable=errcheck --enable=maligned
+# --enable=goconst --enable=gosec
 
 # Tests, both unit tests and integration tests under /tests
 echo


### PR DESCRIPTION
This replaces gometalinter with golangci-lint, which I am told is much
better.

I have enabled the same linters as before, as well as a couple that
also happened to pass and looked useful.