### PR TITLE
More control over in/out formats

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -37,12 +37,14 @@ var generateOptions struct {
 	vmOptions
 
 	stdout bool
+	format string
 }
 
 func init() {
 	initAllVMFlags(generateCmd, &generateOptions.vmOptions)
 
 	generateCmd.PersistentFlags().BoolVar(&generateOptions.stdout, "stdout", false, "print values on stdout")
+	generateCmd.PersistentFlags().StringVar(&generateOptions.format, "format", "", "force all values to this format")
 
 	jk.AddCommand(generateCmd)
 }
@@ -70,6 +72,9 @@ func generate(cmd *cobra.Command, args []string) {
 
 	vm := newVM(&generateOptions.vmOptions, ".")
 	vm.parameters.SetBool("jk.generate.stdout", generateOptions.stdout)
+	if generateOptions.format != "" {
+		vm.parameters.SetString("jk.generate.format", generateOptions.format)
+	}
 
 	if err := vm.Run("@jkcfg/std/cmd/<generate>", fmt.Sprintf(string(std.Module("cmd/generate-module.js")), args[0])); err != nil {
 		if !skipException(err) {

--- a/std/cmd/generate-module.js
+++ b/std/cmd/generate-module.js
@@ -1,9 +1,21 @@
 import * as param from '@jkcfg/std/param';
-import { generate } from '@jkcfg/std/cmd/generate';
+import { generate, OutputFormat } from '@jkcfg/std/cmd/generate';
 import generateDefinition from '%s';
 
-const inputParams = {
+let inputParams = {
   stdout: param.Boolean('jk.generate.stdout', false),
 };
+
+let format = param.String('jk.generate.format', undefined);
+switch (format) {
+case "json":
+  inputParams.format = OutputFormat.JSON;
+  break;
+case "yaml":
+  inputParams.format = OutputFormat.YAML;
+  break;
+default:
+  break;
+}
 
 generate(generateDefinition, inputParams);

--- a/std/cmd/generate.ts
+++ b/std/cmd/generate.ts
@@ -17,10 +17,25 @@ export interface File {
 }
 
 /*
+ * OutputFormat enumerates the values that a "forced format" argument
+ * can take.
+ */
+export enum OutputFormat {
+  JSON = "json",
+  YAML = "yaml",
+}
+
+const outputFormatToFormat = {
+  [OutputFormat.JSON]: std.Format.JSON,
+  [OutputFormat.YAML]: std.Format.YAML,
+};
+
+/*
  * GenerateParams types the optional arguments to generate.
  */
 export interface GenerateParams {
   stdout?: boolean;
+  format?: OutputFormat;
   overwrite?: std.Overwrite;
   writeFile?: (v: any, p: string, o?: WriteOptions) => void;
 }
@@ -77,8 +92,20 @@ const nth = (n: number): string => {
   return n + (s[mod(v - 20, 10)] || s[v] || s[0]);
 };
 
+function splitExtension(path: string): [string, string] {
+  const parts = path.split('.');
+  const ext = parts.pop()
+  // When there's no extension, either there will be a single part (no
+  // dots anywhere), or a path separator in the last part (a dot
+  // somewhere before the last path segment)
+  if (parts.length == 0 || ext.includes('/')) {
+    return [ext, '']
+  }
+  return [parts.join(''), ext]
+}
+
 function extension(path: string): string {
-  return path.split('.').pop();
+  return splitExtension(path)[1]
 }
 
 function formatFromPath(path: string): std.Format {
@@ -157,6 +184,32 @@ function validateFormat(files: RealisedFile[], params: GenerateParams) {
   });
 
   return { valid, showHelp: !valid };
+}
+
+function forceFormat(forced: OutputFormat, files: RealisedFile[]) {
+  for (const file of files) {
+    const { path, value, format, ...rest } = file;
+    // FIXME pretend just forcing YAML for the minute
+    switch (fileFormat(file)) {
+    case std.Format.YAMLStream:
+      if (forced === OutputFormat.JSON) {
+        file.format = std.Format.JSONStream;
+      }
+      break;
+    case std.Format.JSONStream:
+      if (forced == OutputFormat.YAML) {
+        file.format = std.Format.YAMLStream;
+      }
+      break;
+    default:
+      file.format = outputFormatToFormat[forced];
+      break;
+    }
+    const [p, ext] = splitExtension(path);
+    if (ext !== '') {
+      file.path = [p, forced].join('.');
+    }
+  }
 }
 
 function assembleForStdout(values: RealisedFile[]) {
@@ -265,6 +318,10 @@ export function generate(definition: GenerateArg, params: GenerateParams) {
 
     if (!valuesValid) {
       throw new Error('jk-internal-skip: values failed validation');
+    }
+
+    if (params.format !== undefined) {
+      forceFormat(params.format, files)
     }
 
     if (stdout) {


### PR DESCRIPTION
This adds a flag `jk generate --format`, which will force the output
to either YAML or JSON.

If printing to stdout, this means all values are printed as whichever
foramt, with streams being inlined as before.

If writing to files, the file extension when present will be
changed. Values with a stream (or multidoc) format -- YAMLStream,
JSONStream -- will still be written as streams.